### PR TITLE
Prepare for custom URL parser

### DIFF
--- a/src/__tests__/index.ts
+++ b/src/__tests__/index.ts
@@ -3,15 +3,14 @@ import type { MatcherFunction } from "expect";
 
 import type * as libsql from "..";
 import { LibsqlError, createClient } from "..";
-import { ExpandedConfig, expandConfig } from "../config.js";
 
-const config = expandConfig({
+const config = {
     url: process.env.URL ?? "ws://localhost:8080",
     authToken: process.env.AUTH_TOKEN,
-});
+};
 
-const isHttp = config.url.protocol === "http:" || config.url.protocol === "https:";
-const isFile = config.url.protocol === "file:";
+const isHttp = config.url.startsWith("http:") || config.url.startsWith("https:");
+const isFile = config.url.startsWith("file:");
 
 function withClient(f: (c: libsql.Client) => Promise<void>): () => Promise<void> {
     return async () => {

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,5 +1,5 @@
 export interface Config {
-    url: string | URL;
+    url: string;
     authToken?: string;
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,7 +1,7 @@
 import type { Config } from "./api.js";
 import { LibsqlError } from "./api.js";
 
-export interface ExpandedConfig extends Config {
+export interface ExpandedConfig {
     url: URL;
     authToken: string | undefined;
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,7 +7,7 @@ export interface ExpandedConfig {
 }
 
 export function expandConfig(config: Config): ExpandedConfig {
-    const url = config.url instanceof URL ? config.url : new URL(config.url);
+    const url = new URL(config.url);
 
     let authToken = config.authToken;
     for (const [key, value] of url.searchParams.entries()) {

--- a/src/hrana.ts
+++ b/src/hrana.ts
@@ -2,14 +2,19 @@ import * as hrana from "@libsql/hrana-client";
 
 import type { Config, Client, Transaction, ResultSet, InStatement } from "./api.js";
 import { LibsqlError } from "./api.js";
+import type { ExpandedConfig } from "./config.js";
 import { expandConfig, mapLibsqlUrl } from "./config.js";
 
 export * from "./api.js";
 
 export function createClient(config: Config): HranaClient {
-    const expandedConfig = expandConfig(config);
-    const url = mapLibsqlUrl(expandedConfig.url, "wss:");
-    const client = hrana.open(url, expandedConfig.authToken);
+    return _createClient(expandConfig(config));
+}
+
+/** @private */
+export function _createClient(config: ExpandedConfig): HranaClient {
+    const url = mapLibsqlUrl(config.url, "wss:");
+    const client = hrana.open(url, config.authToken);
     return new HranaClient(client);
 }
 

--- a/src/http.ts
+++ b/src/http.ts
@@ -3,15 +3,20 @@ import { fetch } from "@libsql/isomorphic-fetch";
 
 import type { Config, Client } from "./api.js";
 import { InStatement, ResultSet, LibsqlError } from "./api.js";
+import type { ExpandedConfig } from "./config.js";
 import { expandConfig, mapLibsqlUrl } from "./config.js";
 import { stmtToHrana, resultSetFromHrana, mapHranaError } from "./hrana.js";
 
 export * from "./api.js";
 
 export function createClient(config: Config): Client {
-    const expandedConfig = expandConfig(config);
-    const url = mapLibsqlUrl(expandedConfig.url, "https:");
-    return new HttpClient(url, expandedConfig.authToken);
+    return _createClient(expandConfig(config));
+}
+
+/** @private */
+export function _createClient(config: ExpandedConfig): Client {
+    const url = mapLibsqlUrl(config.url, "https:");
+    return new HttpClient(url, config.authToken);
 }
 
 export class HttpClient implements Client {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,17 +1,20 @@
 import type { Config, Client } from "./api.js";
-import { LibsqlError } from "./api.js";
+import type { ExpandedConfig } from "./config.js";
 import { expandConfig } from "./config.js";
-import { createClient as createSqlite3Client } from "./sqlite3.js";
-import { createClient as createWebClient } from "./web.js";
+import { _createClient as _createSqlite3Client } from "./sqlite3.js";
+import { _createClient as _createWebClient } from "./web.js";
 
 export * from "./api.js";
 
 export function createClient(config: Config): Client {
-    const expandedConfig = expandConfig(config);
-    const url = expandedConfig.url;
+    return _createClient(expandConfig(config));
+}
+
+function _createClient(config: ExpandedConfig) {
+    const url = config.url;
     if (url.protocol === "file:") {
-        return createSqlite3Client(expandedConfig);
+        return _createSqlite3Client(config);
     } else {
-        return createWebClient(expandedConfig);
+        return _createWebClient(config);
     }
 }

--- a/src/sqlite3.ts
+++ b/src/sqlite3.ts
@@ -3,13 +3,18 @@ import { Buffer } from "node:buffer";
 
 import type { Config, Client, Transaction, ResultSet, Row, Value, InValue, InStatement } from "./api.js";
 import { LibsqlError } from "./api.js";
+import type { ExpandedConfig } from "./config.js";
 import { expandConfig } from "./config.js";
 
 export * from "./api.js";
 
 export function createClient(config: Config): Client {
-    const expandedConfig = expandConfig(config);
-    const url = expandedConfig.url;
+    return _createClient(expandConfig(config));
+}
+
+/** @private */
+export function _createClient(config: ExpandedConfig): Client {
+    const url = config.url;
     if (url.protocol !== "file:") {
         throw new LibsqlError(
             `URL scheme ${JSON.stringify(url.protocol)} is not supported by the sqlite3 client`,

--- a/src/web.ts
+++ b/src/web.ts
@@ -1,16 +1,23 @@
 import type { Config, Client } from "./api.js";
 import { LibsqlError } from "./api.js";
+import type { ExpandedConfig } from "./config.js";
 import { expandConfig } from "./config.js";
-import { createClient as createHranaClient } from "./hrana.js";
-import { createClient as createHttpClient } from "./http.js";
+import { _createClient as _createHranaClient } from "./hrana.js";
+import { _createClient as _createHttpClient } from "./http.js";
+
+export * from "./api.js";
 
 export function createClient(config: Config): Client {
-    const expandedConfig = expandConfig(config);
-    const url = expandedConfig.url;
+    return _createClient(expandConfig(config));
+}
+
+/** @private */
+export function _createClient(config: ExpandedConfig): Client {
+    const url = config.url;
     if (url.protocol === "http:" || url.protocol === "https:") {
-        return createHttpClient(expandedConfig);
+        return _createHttpClient(config);
     } else if (url.protocol === "ws:" || url.protocol === "wss:" || url.protocol === "libsql:") {
-        return createHranaClient(expandedConfig);
+        return _createHranaClient(config);
     } else {
         throw new LibsqlError(
             `URL scheme ${JSON.stringify(url.protocol)} is not supported`,


### PR DESCRIPTION
We need a custom URL parser to support relative file URLs. It is not ready but we need to release 0.1.0 asap, so this PR merges the compatibility-breaking changes, so that the new URL parser can land in a minor release.