### PR TITLE
Support `file:` URLs with relative paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,14 +24,21 @@ You can also connect to a local SQLite database with:
 import { createClient } from "@libsql/client"
 
 const config = {
-  url: "file:/tmp/example.db"
+  url: "file:local.db"
 };
 const db = createClient(config);
 const rs = await db.execute("SELECT * FROM users");
 console.log(rs);
 ```
 
-## Features
+## Supported URLs
 
-* Connect to `sqld` (with HTTP or WebSockets)
-* Connect to a local SQLite database
+The client can connect to the database using different methods depending on the scheme (protocol) of the passed URL:
+
+* `file:` connects to a local SQLite database (using `better-sqlite3`)
+  * `file:/absolute/path` or `file:///absolute/path` is an absolute path on local filesystem
+  * `file:relative/path` is a relative path on local filesystem
+  * (`file://path` is not a valid URL)
+* `ws:` or `wss:` connect to `sqld` using WebSockets (the Hrana protocol).
+* `http:` or `https:` connect to `sqld` using HTTP. The `transaction()` API is not available in this case.
+* `libsql:` is equivalent to `wss:`.

--- a/examples/README.md
+++ b/examples/README.md
@@ -11,7 +11,7 @@ npm i && npm run build
 First, run the example with local SQLite:
 
 ```console
-URL="file:/tmp/example.db" npm run start
+URL="file:local.db" npm run start
 ```
 
 Then, start up a `sqld` server:

--- a/examples/src/example.ts
+++ b/examples/src/example.ts
@@ -1,7 +1,7 @@
 import { createClient } from "@libsql/client"
 
 async function example() {
-  const url = process.env.URL ?? "file:/tmp/test.db";
+  const url = process.env.URL ?? "file:local.db";
   const config = {
     url
   };

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,4 +3,5 @@ export default {
     moduleNameMapper: {
         '^(\\.{1,2}/.*)\\.js$': '$1',
     },
+    testMatch: ["**/__tests__/*.test.[jt]s"],
 }

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -28,7 +28,7 @@ function withClient(f: (c: libsql.Client) => Promise<void>): () => Promise<void>
 describe("createClient()", () => {
     test("URL scheme not supported", () => {
         expect(() => createClient({url: "ftp://localhost"}))
-            .toThrow(expect.toBeLibsqlError("URL_SCHEME_NOT_SUPPORTED", /"ftp:"/));
+            .toThrow(expect.toBeLibsqlError("URL_SCHEME_NOT_SUPPORTED", /"ftp"/));
     });
 
     test("URL param not supported", () => {

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -1,8 +1,10 @@
 import { expect } from "@jest/globals";
 import type { MatcherFunction } from "expect";
 
+import "./helpers.js";
+
 import type * as libsql from "..";
-import { LibsqlError, createClient } from "..";
+import { createClient } from "..";
 
 const config = {
     url: process.env.URL ?? "ws://localhost:8080",
@@ -21,42 +23,6 @@ function withClient(f: (c: libsql.Client) => Promise<void>): () => Promise<void>
             c.close();
         }
     };
-}
-
-const toBeLibsqlError: MatcherFunction<[code?: string, message?: RegExp]> =
-    function (actual, code?, messageRe?) {
-        const pass = actual instanceof LibsqlError
-            && (code === undefined || actual.code === code)
-            && (messageRe === undefined || actual.message.match(messageRe) !== null);
-
-        const message = (): string => {
-            const parts = [];
-            parts.push("expected ");
-            parts.push(this.utils.printReceived(actual));
-            parts.push(pass ? " not to be " : " to be ");
-            parts.push("an instance of LibsqlError");
-            if (code !== undefined) {
-                parts.push(" with error code ");
-                parts.push(this.utils.printExpected(code));
-            }
-            if (messageRe !== undefined) {
-                parts.push(" with error message matching ");
-                parts.push(this.utils.printExpected(messageRe));
-            }
-            return parts.join("");
-        };
-
-        return {pass, message};
-    };
-
-expect.extend({toBeLibsqlError});
-declare module "expect" {
-    interface AsymmetricMatchers {
-        toBeLibsqlError(code?: string, messageRe?: RegExp): void;
-    }
-    interface Matchers<R> {
-        toBeLibsqlError(code?: string, messageRe?: RegExp): R;
-    }
 }
 
 describe("createClient()", () => {

--- a/src/__tests__/helpers.ts
+++ b/src/__tests__/helpers.ts
@@ -1,0 +1,40 @@
+import { expect } from "@jest/globals";
+import type { MatcherFunction } from "expect";
+
+import { LibsqlError } from "..";
+
+const toBeLibsqlError: MatcherFunction<[code?: string, message?: RegExp]> =
+    function (actual, code?, messageRe?) {
+        const pass = actual instanceof LibsqlError
+            && (code === undefined || actual.code === code)
+            && (messageRe === undefined || actual.message.match(messageRe) !== null);
+
+        const message = (): string => {
+            const parts = [];
+            parts.push("expected ");
+            parts.push(this.utils.printReceived(actual));
+            parts.push(pass ? " not to be " : " to be ");
+            parts.push("an instance of LibsqlError");
+            if (code !== undefined) {
+                parts.push(" with error code ");
+                parts.push(this.utils.printExpected(code));
+            }
+            if (messageRe !== undefined) {
+                parts.push(" with error message matching ");
+                parts.push(this.utils.printExpected(messageRe));
+            }
+            return parts.join("");
+        };
+
+        return {pass, message};
+    };
+
+expect.extend({toBeLibsqlError});
+declare module "expect" {
+    interface AsymmetricMatchers {
+        toBeLibsqlError(code?: string, messageRe?: RegExp): void;
+    }
+    interface Matchers<R> {
+        toBeLibsqlError(code?: string, messageRe?: RegExp): R;
+    }
+}

--- a/src/__tests__/uri.test.ts
+++ b/src/__tests__/uri.test.ts
@@ -1,0 +1,199 @@
+import { expect } from "@jest/globals";
+import type { MatcherFunction } from "expect";
+
+import "./helpers.js";
+
+import { parse } from "../uri.js";
+
+describe("URI parse", () => {
+    test("authority and path", () => {
+        const cases = [
+            {text: "file://localhost", path: ""},
+            {text: "file://localhost/", path: "/"},
+            {text: "file://localhost/absolute/path", path: "/absolute/path"},
+            {text: "file://localhost/k%C5%AF%C5%88", path: "/kůň"},
+        ];
+        for (const {text, path} of cases) {
+            expect(parse(text)).toEqual({
+                scheme: "file",
+                authority: {host: "localhost"},
+                path,
+            });
+        }
+    });
+
+    test("empty authority and path", () => {
+        const cases = [
+            {text: "file:///absolute/path", path: "/absolute/path"},
+            {text: "file://", path: ""},
+            {text: "file:///k%C5%AF%C5%88", path: "/kůň"},
+        ];
+        for (const {text, path} of cases) {
+            expect(parse(text)).toEqual({
+                scheme: "file",
+                authority: {host: ""},
+                path,
+            });
+        }
+    });
+
+    test("no authority and path", () => {
+        const cases = [
+            {text: "file:/absolute/path", path: "/absolute/path"},
+            {text: "file:relative/path", path: "relative/path"},
+            {text: "file:", path: ""},
+            {text: "file:C:/path/to/file", path: "C:/path/to/file"},
+            {text: "file:k%C5%AF%C5%88", path: "kůň"},
+        ];
+        for (const {text, path} of cases) {
+            expect(parse(text)).toEqual({
+                scheme: "file",
+                path,
+            });
+        }
+    });
+
+    test("authority", () => {
+        const hosts = [
+            {text: "localhost", host: "localhost"},
+            {text: "domain.name", host: "domain.name"},
+            {text: "some$weird.%20!name", host: "some$weird. !name"},
+            {text: "1.20.255.99", host: "1.20.255.99"},
+            {text: "[2001:4860:4802:32::a]", host: "[2001:4860:4802:32::a]"},
+            {text: "%61", host: "a"},
+            {text: "100%2e100%2e100%2e100", host: "100.100.100.100"},
+            {text: "k%C5%AF%C5%88", host: "kůň"},
+        ];
+        const ports = [
+            {text: "", port: undefined},
+            {text: ":", port: undefined},
+            {text: ":0", port: 0},
+            {text: ":99", port: 99},
+            {text: ":65535", port: 65535},
+        ];
+        const userinfos = [
+            {text: "", userinfo: undefined},
+            {text: "@", userinfo: {username: ""}},
+            {text: "alice@", userinfo: {username: "alice"}},
+            {text: "alice:secret@", userinfo: {username: "alice", password: "secret"}},
+            {text: "alice:sec:et@", userinfo: {username: "alice", password: "sec:et"}},
+            {text: "alice%3Asecret@", userinfo: {username: "alice:secret"}},
+            {text: "alice:s%65cret@", userinfo: {username: "alice", password: "secret"}},
+        ];
+
+        for (const {text: hostText, host} of hosts) {
+            for (const {text: portText, port} of ports) {
+                for (const {text: userText, userinfo} of userinfos) {
+                    const text = `http://${userText}${hostText}${portText}`;
+                    expect(parse(text)).toEqual({
+                        scheme: "http",
+                        authority: {host, port, userinfo},
+                        path: "",
+                    });
+                }
+            }
+        }
+    });
+
+    test("query", () => {
+        const cases = [
+            {text: "?", pairs: []},
+            {text: "?key=value", pairs: [
+                {key: "key", value: "value"},
+            ]},
+            {text: "?&key=value", pairs: [
+                {key: "key", value: "value"},
+            ]},
+            {text: "?key=value&&", pairs: [
+                {key: "key", value: "value"},
+            ]},
+            {text: "?a", pairs: [
+                {key: "a", value: ""},
+            ]},
+            {text: "?a=", pairs: [
+                {key: "a", value: ""},
+            ]},
+            {text: "?=a", pairs: [
+                {key: "", value: "a"},
+            ]},
+            {text: "?=", pairs: [
+                {key: "", value: ""},
+            ]},
+            {text: "?a=b=c", pairs: [
+                {key: "a", value: "b=c"},
+            ]},
+            {text: "?a=b&c=d", pairs: [
+                {key: "a", value: "b"},
+                {key: "c", value: "d"},
+            ]},
+            {text: "?a+b=c", pairs: [
+                {key: "a b", value: "c"},
+            ]},
+            {text: "?a=b+c", pairs: [
+                {key: "a", value: "b c"},
+            ]},
+            {text: "?a?b", pairs: [
+                {key: "a?b", value: ""},
+            ]},
+            {text: "?%61=%62", pairs: [
+                {key: "a", value: "b"},
+            ]},
+            {text: "?a%3db", pairs: [
+                {key: "a=b", value: ""},
+            ]},
+            {text: "?a=%2b", pairs: [
+                {key: "a", value: "+"},
+            ]},
+            {text: "?%2b=b", pairs: [
+                {key: "+", value: "b"},
+            ]},
+            {text: "?a=b%26c", pairs: [
+                {key: "a", value: "b&c"},
+            ]},
+            {text: "?a=k%C5%AF%C5%88", pairs: [
+                {key: "a", value: "kůň"},
+            ]},
+        ];
+        for (const {text: queryText, pairs} of cases) {
+            const text = `file:${queryText}`;
+            expect(parse(text)).toEqual({
+                scheme: "file",
+                path: "",
+                query: {pairs},
+            });
+        }
+    });
+
+    test("fragment", () => {
+        const cases = [
+            {text: "", fragment: undefined},
+            {text: "#a", fragment: "a"},
+            {text: "#a?b", fragment: "a?b"},
+            {text: "#%61", fragment: "a"},
+            {text: "#k%C5%AF%C5%88", fragment: "kůň"},
+        ];
+        for (const {text: fragmentText, fragment} of cases) {
+            const text = `file:${fragmentText}`;
+            expect(parse(text)).toEqual({
+                scheme: "file",
+                path: "",
+                fragment,
+            });
+        }
+    });
+
+    test("parse errors", () => {
+        const cases = [
+            {text: "", message: /format/},
+            {text: "foo", message: /format/},
+            {text: "h$$p://localhost", message: /format/},
+            {text: "h%74%74p://localhost", message: /format/},
+            {text: "http://localhost:%38%38", message: /authority/},
+            {text: "file:k%C5%C5%88", message: /percent encoding/},
+        ];
+
+        for (const {text, message} of cases) {
+            expect(() => parse(text)).toThrow(expect.toBeLibsqlError("URL_INVALID", message));
+        }
+    });
+});

--- a/src/uri.ts
+++ b/src/uri.ts
@@ -1,0 +1,134 @@
+// URI parser based on RFC 3986
+// We can't use the standard `URL` object, because we want to support relative `file:` URLs like
+// `file:relative/path/database.db`, which are not correct according to RFC 8089, which standardizes the
+// `file` scheme.
+
+import { LibsqlError } from "./api.js";
+
+interface Uri {
+    scheme: string;
+    authority: Authority | undefined;
+    path: string;
+    query: Query | undefined;
+    fragment: string | undefined;
+}
+
+interface HierPart {
+    authority: Authority | undefined;
+    path: string;
+}
+
+interface Authority {
+    host: string;
+    port: number | undefined;
+    userinfo: Userinfo | undefined;
+}
+
+interface Userinfo {
+    username: string;
+    password: string | undefined;
+}
+
+interface Query {
+    pairs: Array<KeyValue>,
+}
+
+interface KeyValue {
+    key: string;
+    value: string;
+}
+
+export function parse(text: string): Uri {
+    const match = URI_RE.exec(text);
+    if (match === null) {
+        throw new LibsqlError("The URL is not in a valid format", "URL_INVALID");
+    }
+
+    const groups = match.groups!;
+    const scheme = groups["scheme"]!;
+    const authority = groups["authority"] !== undefined 
+        ? parseAuthority(groups["authority"]) : undefined;
+    const path = percentDecode(groups["path"]!);
+    const query = groups["query"] !== undefined 
+        ? parseQuery(groups["query"]) : undefined;
+    const fragment = groups["fragment"] !== undefined
+        ? percentDecode(groups["fragment"]) : undefined;
+    return { scheme, authority, path, query, fragment };
+}
+
+const URI_RE = (() => {
+    const SCHEME = '(?<scheme>[A-Za-z][A-Za-z.+-]*)';
+    const AUTHORITY = '(?<authority>[^/?#]*)';
+    const PATH = '(?<path>[^?#]*)';
+    const QUERY = '(?<query>[^#]*)';
+    const FRAGMENT = '(?<fragment>.*)'
+    return new RegExp(`^${SCHEME}:(//${AUTHORITY})?${PATH}(\\?${QUERY})?(#${FRAGMENT})?$`, "su");
+})();
+
+function parseAuthority(text: string): Authority {
+    const match = AUTHORITY_RE.exec(text);
+    if (match === null) {
+        throw new LibsqlError("The authority part of the URL is not valid", "URL_INVALID");
+    }
+
+    const groups = match.groups!;
+    const host = percentDecode(groups["host"]);
+    const port = groups["port"] 
+        ? parseInt(groups["port"], 10) 
+        : undefined;
+    const userinfo = groups["username"] !== undefined
+        ? {
+            username: percentDecode(groups["username"]),
+            password: groups["password"] !== undefined
+                ? percentDecode(groups["password"]) : undefined,
+        }
+        : undefined;
+    return { host, port, userinfo };
+}
+
+const AUTHORITY_RE = (() => {
+    const USERINFO = '(?<username>[^:]*)(:(?<password>.*))?';
+    const HOST = '(?<host>[^:]*|(\\[.*\\]))';
+    const PORT = '(?<port>[0-9]*)';
+    return new RegExp(`^(${USERINFO}@)?${HOST}(:${PORT})?$`);
+})();
+
+// Query string is parsed as application/x-www-form-urlencoded according to the Web URL standard:
+// https://url.spec.whatwg.org/#urlencoded-parsing
+function parseQuery(text: string): Query {
+    const sequences = text.split("&");
+    const pairs = [];
+    for (const sequence of sequences) {
+        if (sequence === "") {
+            continue;
+        }
+
+        let key: string;
+        let value: string;
+        const splitIdx = sequence.indexOf("=");
+        if (splitIdx < 0) {
+            key = sequence;
+            value = "";
+        } else {
+            key = sequence.substring(0, splitIdx);
+            value = sequence.substring(splitIdx+1);
+        }
+
+        pairs.push({
+            key: percentDecode(key.replaceAll("+", " ")),
+            value: percentDecode(value.replaceAll("+", " ")),
+        });
+    }
+    return { pairs };
+}
+
+function percentDecode(text: string): string {
+    try {
+        return decodeURIComponent(text);
+    } catch (e) {
+        if (e instanceof URIError) {
+            throw new LibsqlError("URL component has invalid percent encoding", "URL_INVALID", e);
+        }
+        throw e;
+    }
+}

--- a/src/web.ts
+++ b/src/web.ts
@@ -13,14 +13,15 @@ export function createClient(config: Config): Client {
 
 /** @private */
 export function _createClient(config: ExpandedConfig): Client {
-    const url = config.url;
-    if (url.protocol === "http:" || url.protocol === "https:") {
-        return _createHttpClient(config);
-    } else if (url.protocol === "ws:" || url.protocol === "wss:" || url.protocol === "libsql:") {
+    const scheme = config.scheme.toLowerCase();
+    if (scheme === "libsql" || scheme === "wss" || scheme === "ws") {
         return _createHranaClient(config);
+    } else if (scheme === "https" || scheme === "http") {
+        return _createHttpClient(config);
     } else {
         throw new LibsqlError(
-            `URL scheme ${JSON.stringify(url.protocol)} is not supported`,
+            'The client that uses Web standard APIs supports only "libsql", "wss", "ws", "https" and "http" URLs, ' +
+                `got ${JSON.stringify(config.scheme)}`,
             "URL_SCHEME_NOT_SUPPORTED",
         );
     }


### PR DESCRIPTION
We want to support relative `file:` URLs like `file:local.db`, which refers to file `local.db` in the current directory. Unfortunately, these URLs are not valid according to [RFC 8089](https://datatracker.ietf.org/doc/html/rfc8089), which defines the "file" URI scheme, so the standard `URL` object from JavaScript is not able to parse them correctly.

For this reason, this PR introduces a custom parser that parses URIs according to the general syntax from [RFC 3983](https://datatracker.ietf.org/doc/html/rfc3986), without applying scheme-specific restrictions.