### PR TITLE
Add `lastInsertRowid` to `ResultSet`

### DIFF
--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -89,6 +89,21 @@ describe("execute()", () => {
         const rs = await c.execute("DELETE FROM t WHERE a >= 3");
         expect(rs.rowsAffected).toStrictEqual(3);
     }));
+
+    test("lastInsertRowid with INSERT", withClient(async (c) => {
+        await c.batch([
+            "DROP TABLE IF EXISTS t",
+            "CREATE TABLE t (a)",
+            "INSERT INTO t VALUES ('one'), ('two')",
+        ]);
+        const insertRs = await c.execute("INSERT INTO t VALUES ('three')");
+        expect(insertRs.lastInsertRowid).not.toBeUndefined();
+        const selectRs = await c.execute({
+            sql: "SELECT a FROM t WHERE ROWID = ?",
+            args: [insertRs.lastInsertRowid!],
+        });
+        expect(Array.from(selectRs.rows[0])).toStrictEqual(["three"]);
+    }));
 });
 
 describe("values", () => {

--- a/src/api.ts
+++ b/src/api.ts
@@ -23,6 +23,7 @@ export interface ResultSet {
     columns: Array<string>;
     rows: Array<Row>;
     rowsAffected: number;
+    lastInsertRowid: bigint | undefined;
 }
 
 export interface Row {

--- a/src/hrana.ts
+++ b/src/hrana.ts
@@ -193,6 +193,8 @@ export function resultSetFromHrana(hranaRows: hrana.RowsResult): ResultSet {
         columns: hranaRows.columnNames.map(c => c ?? ""),
         rows: hranaRows.rows,
         rowsAffected: hranaRows.affectedRowCount,
+        lastInsertRowid: hranaRows.lastInsertRowid !== undefined
+            ? BigInt(hranaRows.lastInsertRowid) : undefined,
     };
 }
 

--- a/src/sqlite3.ts
+++ b/src/sqlite3.ts
@@ -186,11 +186,15 @@ function executeStmt(db: Database.Database, stmt: InStatement): ResultSet {
         if (returnsData) {
             const columns = Array.from(sqlStmt.columns().map(col => col.name));
             const rows = sqlStmt.all(args).map(sqlRow => rowFromSql(sqlRow, columns));
-            const rowsAffected = 0; // TODO: can we get this info from better-sqlite3?
-            return { columns, rows, rowsAffected };
+            // TODO: can we get this info from better-sqlite3?
+            const rowsAffected = 0;
+            const lastInsertRowid = undefined;
+            return { columns, rows, rowsAffected, lastInsertRowid };
         } else {
             const info = sqlStmt.run(args);
-            return { columns: [], rows: [], rowsAffected: info.changes };
+            const rowsAffected = info.changes;
+            const lastInsertRowid = BigInt(info.lastInsertRowid);
+            return { columns: [], rows: [], rowsAffected, lastInsertRowid };
         }
     } catch (e) {
         if (e instanceof Database.SqliteError) {


### PR DESCRIPTION
The last inserted rowid is returned from Hrana and HTTP APIs. Let's expose it in the client, too.

The only possible issue is the type of the `lastInsertRowid` field. There are three options:

- `bigint`: this is the best way to represent a 64-bit integer in JavaScript, but we don't use bigints anywhere else in the API
- `string`: we convert JavaScript bigint to SQLite string when storing data into the database
- `number`: we convert SQLite integers to JavaScript `number`-s (doubles) when loading data from database, but a `number` cannot represent all ROWIDs

I decided to go for `bigint`, because it seems to be least likely to give trouble: it can represent all ROWIDs, and when passed back to SQLite, the client converts it to a string, which SQLite converts back to an integer. (Perhaps it would be better to convert JavaScript `bigint` to a SQLite integer (and throw an exception if it overflows), but this would break backwards compatibility, so let's do it in the next major release.)