### PR TITLE
Reconnect the Hrana client on error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "0.1.4-pre",
             "license": "MIT",
             "dependencies": {
-                "@libsql/hrana-client": "^0.3.6",
+                "@libsql/hrana-client": "^0.3.9",
                 "@libsql/isomorphic-fetch": "^0.1.1",
                 "better-sqlite3": "^8.0.1",
                 "js-base64": "^3.7.5"
@@ -960,9 +960,9 @@
             }
         },
         "node_modules/@libsql/hrana-client": {
-            "version": "0.3.6",
-            "resolved": "https://registry.npmjs.org/@libsql/hrana-client/-/hrana-client-0.3.6.tgz",
-            "integrity": "sha512-FoJkesoUrlx6u8KWsYEuj9viHMzXId21v5wAPTj4++cTvFmAw/lctxjzRwxTkfyxoqU2nwAi73VfUs/9vLJFXQ==",
+            "version": "0.3.9",
+            "resolved": "https://registry.npmjs.org/@libsql/hrana-client/-/hrana-client-0.3.9.tgz",
+            "integrity": "sha512-vVQU+4629HI3MAaX3hbIz5kYOWVZ5syKjpkQ6oGR+WR0GwsiT4KheifO5e+wM4QKZ5FCjTVzOhA45HFvU5e4kA==",
             "dependencies": {
                 "@libsql/isomorphic-ws": "^0.1.2",
                 "js-base64": "^3.7.5"

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
         "typescript": "^4.9.4"
     },
     "dependencies": {
-        "@libsql/hrana-client": "^0.3.6",
+        "@libsql/hrana-client": "^0.3.9",
         "@libsql/isomorphic-fetch": "^0.1.1",
         "better-sqlite3": "^8.0.1",
         "js-base64": "^3.7.5"

--- a/src/api.ts
+++ b/src/api.ts
@@ -57,6 +57,7 @@ export class LibsqlError extends Error {
         }
         super(message, { cause });
         this.code = code;
+        this.name = "LibsqlError";
     }
 }
 


### PR DESCRIPTION
The Fly infrastructure on Turso closes TCP connections after a period of inactivity. This PR implements automatic reconnect of the Hrana client, which should fix this issue.