### PR TITLE
Optimize batch statements execution

### DIFF
--- a/src/sqlite3.ts
+++ b/src/sqlite3.ts
@@ -83,9 +83,9 @@ export class Sqlite3Client implements Client {
         this.#checkNotClosed();
         const db = new Database(this.path, this.options);
         try {
-            executeStmt(db, "BEGIN");
+            if (stmts.length > 1) executeStmt(db, "BEGIN");
             const resultSets = stmts.map(stmt => executeStmt(db, stmt));
-            executeStmt(db, "COMMIT");
+            if (stmts.length > 1) executeStmt(db, "COMMIT");
             return resultSets;
         } finally {
             db.close();


### PR DESCRIPTION
Wrap statements with BEGIN + COMMIT only if there are more than one statement.

Kinda relates to:  [sqld #100 Optimize single statement execution in JavaScript client](https://github.com/libsql/sqld/issues/100)