### PR TITLE
Cache SQL texts with Hrana 2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,8 +35,12 @@ jobs:
     - name: "Build"
       run: "npm run build"
 
-    - name: "Test WebSocket"
-      run: "python hrana-test-server/test_server.py npm test"
+    - name: "Test Hrana 1"
+      run: "python hrana-test-server/server_v1.py npm test"
+      env:
+        "URL": "ws://localhost:8080"
+    - name: "Test Hrana 2"
+      run: "python hrana-test-server/server_v2.py npm test"
       env:
         "URL": "ws://localhost:8080"
     - name: "Test HTTP"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "0.1.5-pre",
             "license": "MIT",
             "dependencies": {
-                "@libsql/hrana-client": "^0.3.9",
+                "@libsql/hrana-client": "^0.3.10",
                 "@libsql/isomorphic-fetch": "^0.1.1",
                 "better-sqlite3": "^8.0.1",
                 "js-base64": "^3.7.5"
@@ -960,9 +960,9 @@
             }
         },
         "node_modules/@libsql/hrana-client": {
-            "version": "0.3.9",
-            "resolved": "https://registry.npmjs.org/@libsql/hrana-client/-/hrana-client-0.3.9.tgz",
-            "integrity": "sha512-vVQU+4629HI3MAaX3hbIz5kYOWVZ5syKjpkQ6oGR+WR0GwsiT4KheifO5e+wM4QKZ5FCjTVzOhA45HFvU5e4kA==",
+            "version": "0.3.10",
+            "resolved": "https://registry.npmjs.org/@libsql/hrana-client/-/hrana-client-0.3.10.tgz",
+            "integrity": "sha512-SrQJulhtYR7+5bJ1WkUfgXq9PYo4QkeD7IHqAfMc29RraubjMd3xXQyOGhtzgY0q+vfi8qDqTlcCbx/H7OFw9Q==",
             "dependencies": {
                 "@libsql/isomorphic-ws": "^0.1.2",
                 "js-base64": "^3.7.5"

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
         "typescript": "^4.9.4"
     },
     "dependencies": {
-        "@libsql/hrana-client": "^0.3.9",
+        "@libsql/hrana-client": "^0.3.10",
         "@libsql/isomorphic-fetch": "^0.1.1",
         "better-sqlite3": "^8.0.1",
         "js-base64": "^3.7.5"

--- a/src/hrana.ts
+++ b/src/hrana.ts
@@ -5,6 +5,7 @@ import { LibsqlError } from "./api.js";
 import type { ExpandedConfig } from "./config.js";
 import { expandConfig } from "./config.js";
 import { supportedUrlLink } from "./help.js";
+import { Lru } from "./lru.js";
 import { encodeBaseUrl } from "./uri.js";
 
 export * from "./api.js";
@@ -49,25 +50,37 @@ export function _createClient(config: ExpandedConfig): HranaClient {
     return new HranaClient(client, url, config.authToken);
 }
 
+const sqlCacheCapacity = 100;
+
 export class HranaClient implements Client {
-    #client: hrana.Client;
     #url: URL;
     #authToken: string | undefined;
     closed: boolean;
 
+    #client: hrana.Client;
+    #sqlCache: Lru<string, hrana.Sql>;
+
     /** @private */
     constructor(client: hrana.Client, url: URL, authToken: string | undefined) {
-        this.#client = client;
         this.#url = url;
         this.#authToken = authToken;
         this.closed = false;
+
+        this.#client = client;
+        this.#sqlCache = new Lru();
     }
 
     async execute(stmt: InStatement): Promise<ResultSet> {
+        const useSqlCache = await this._useSqlCache();
         const stream = this.#openStream();
         try {
             const hranaStmt = stmtToHrana(stmt);
+            if (useSqlCache) {
+                this._applySqlCache(hranaStmt);
+            }
+
             const hranaRows = await stream.query(hranaStmt);
+            this._evictSqlCache();
             return resultSetFromHrana(hranaRows);
         } catch (e) {
             throw mapHranaError(e);
@@ -77,6 +90,7 @@ export class HranaClient implements Client {
     }
 
     async batch(stmts: Array<InStatement>): Promise<Array<ResultSet>> {
+        const useSqlCache = await this._useSqlCache();
         const stream = this.#openStream();
         try {
             const batch = stream.batch();
@@ -87,6 +101,10 @@ export class HranaClient implements Client {
             let lastStep = beginStep;
             const stmtPromises = stmts.map((stmt) => {
                 const hranaStmt = stmtToHrana(stmt);
+                if (useSqlCache) {
+                    this._applySqlCache(hranaStmt);
+                }
+
                 const stmtStep = batch.step()
                     .condition(hrana.BatchCond.ok(lastStep));
                 const stmtPromise = stmtStep.query(hranaStmt);
@@ -104,6 +122,7 @@ export class HranaClient implements Client {
             rollbackStep.run("ROLLBACK").catch(_ => undefined);
 
             await batch.execute();
+            this._evictSqlCache();
 
             const resultSets = [];
             for (const stmtPromise of stmtPromises) {
@@ -127,10 +146,11 @@ export class HranaClient implements Client {
     }
 
     async transaction(): Promise<HranaTransaction> {
+        const useSqlCache = await this._useSqlCache();
         const stream = this.#openStream();
         try {
             await stream.run("BEGIN");
-            return new HranaTransaction(stream);
+            return new HranaTransaction(this, stream, useSqlCache);
         } catch (e) {
             stream.close();
             throw mapHranaError(e);
@@ -143,6 +163,7 @@ export class HranaClient implements Client {
         }
 
         if (this.#client.closed) {
+            this.#sqlCache.clear();
             try {
                 this.#client = hrana.open(this.#url, this.#authToken);
             } catch (e) {
@@ -157,14 +178,49 @@ export class HranaClient implements Client {
         this.#client.close();
         this.closed = true;
     }
+
+    /** @private */
+    async _useSqlCache(): Promise<boolean> {
+        return await this.#client.getVersion() >= 2;
+    }
+
+    /** @private */
+    _applySqlCache(hranaStmt: hrana.Stmt): void {
+        if (typeof hranaStmt.sql !== "string") {
+            return;
+        }
+        const sqlText: string = hranaStmt.sql;
+
+        let sqlObj = this.#sqlCache.get(sqlText);
+        if (sqlObj === undefined) {
+            sqlObj = this.#client.storeSql(sqlText);
+            this.#sqlCache.set(sqlText, sqlObj);
+        }
+
+        if (sqlObj !== undefined) {
+            hranaStmt.sql = sqlObj;
+        }
+    }
+
+    /** @private */
+    _evictSqlCache(): void {
+        while (this.#sqlCache.size > sqlCacheCapacity) {
+            const sqlObj = this.#sqlCache.deleteLru()!;
+            sqlObj.close();
+        }
+    }
 }
 
 export class HranaTransaction implements Transaction {
+    #client: HranaClient;
     stream: hrana.Stream;
+    #useSqlCache: boolean;
 
     /** @private */
-    constructor(stream: hrana.Stream) {
+    constructor(client: HranaClient, stream: hrana.Stream, useSqlCache: boolean) {
+        this.#client = client;
         this.stream = stream;
+        this.#useSqlCache = useSqlCache;
     }
 
     async execute(stmt: InStatement): Promise<ResultSet> {
@@ -174,10 +230,19 @@ export class HranaTransaction implements Transaction {
                 "TRANSACTION_CLOSED",
             );
         }
-        const hranaStmt = stmtToHrana(stmt);
-        const hranaRows = await this.stream.query(hranaStmt)
-            .catch(e => { throw mapHranaError(e); });
-        return resultSetFromHrana(hranaRows);
+
+        try {
+            const hranaStmt = stmtToHrana(stmt);
+            if (this.#useSqlCache) {
+                this.#client._applySqlCache(hranaStmt);
+            }
+
+            const hranaRows = await this.stream.query(hranaStmt);
+            this.#client._evictSqlCache();
+            return resultSetFromHrana(hranaRows);
+        } catch (e) {
+            throw mapHranaError(e);
+        }
     }
 
     async rollback(): Promise<void> {

--- a/src/lru.ts
+++ b/src/lru.ts
@@ -1,0 +1,39 @@
+export class Lru<K, V> {
+    // This maps keys to the cache values. The entries are ordered by their last use (entires that were used
+    // most recently are at the end).
+    #cache: Map<K, V>;
+
+    constructor() {
+        this.#cache = new Map();
+    }
+
+    get(key: K): V | undefined {
+        const value = this.#cache.get(key);
+        if (value !== undefined) {
+            // move the entry to the back of the Map
+            this.#cache.delete(key);
+            this.#cache.set(key, value);
+        }
+        return value;
+    }
+
+    set(key: K, value: V): void {
+        this.#cache.set(key, value);
+    }
+
+    deleteLru(): V | undefined {
+        for (const [key, value] of this.#cache.entries()) {
+            this.#cache.delete(key);
+            return value;
+        }
+        return undefined;
+    }
+
+    clear(): void {
+        this.#cache.clear();
+    }
+
+    get size(): number {
+        return this.#cache.size;
+    }
+}

--- a/src/lru.ts
+++ b/src/lru.ts
@@ -29,10 +29,6 @@ export class Lru<K, V> {
         return undefined;
     }
 
-    clear(): void {
-        this.#cache.clear();
-    }
-
     get size(): number {
         return this.#cache.size;
     }


### PR DESCRIPTION
This PR implements transparent caching of SQL texts on the server with Hrana 2. If the server supports only Hrana 1, we fall back to sending all SQL texts verbatim.

This change reduces network traffic in case the user executes the same statement repeatedly, possibly with different arguments.