### PR TITLE
Add tests for naive INSERT/UPDATE/DELETE parsing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,6 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       "CLOUDFLARE_API_TOKEN": "${{ secrets.CLOUDFLARE_API_TOKEN }}"
+      "NGROK_AUTHTOKEN": "${{ secrets.NGROK_AUTHTOKEN }}"
     steps:
     - name: "Checkout this repo"
       uses: actions/checkout@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,14 +39,22 @@ jobs:
       run: "python hrana-test-server/server_v1.py npm test"
       env:
         "URL": "ws://localhost:8080"
+        "SERVER": "test_v1"
     - name: "Test Hrana 2"
       run: "python hrana-test-server/server_v2.py npm test"
       env:
         "URL": "ws://localhost:8080"
-    - name: "Test HTTP"
-      run: "python hrana-test-server/test_server.py npm test"
+        "SERVER": "test_v2"
+    - name: "Test HTTP 1"
+      run: "python hrana-test-server/server_v1.py npm test"
       env:
         "URL": "http://localhost:8080"
+        "SERVER": "test_v1"
+    - name: "Test HTTP 2"
+      run: "python hrana-test-server/server_v2.py npm test"
+      env:
+        "URL": "http://localhost:8080"
+        "SERVER": "test_v2"
     - name: "Test local file"
       run: "npm test"
       env:
@@ -96,7 +104,7 @@ jobs:
       env:
         "LOCAL": "1"
         "URL": "ws://localhost:8080"
-    - name: "Local test with HTTP"
+    - name: "Local test with HTTP 1"
       run: "cd smoke_test/workers && python ../../hrana-test-server/server_v1.py node test.js"
       env:
         "LOCAL": "1"
@@ -112,7 +120,7 @@ jobs:
       env:
         "LOCAL": "0"
         "URL": "ws://localhost:8080"
-    - name: "Non-local test with HTTP"
+    - name: "Non-local test with HTTP 1"
       run: "cd smoke_test/workers && python ../../hrana-test-server/server_v1.py node test.js"
       env:
         "LOCAL": "0"

--- a/smoke_test/workers/package.json
+++ b/smoke_test/workers/package.json
@@ -1,6 +1,6 @@
 {
     "devDependencies": {
-        "ngrok": "^4.3.3",
+        "ngrok": "^5.0.0-beta.2",
         "wrangler": "^2.20.0"
     }
 }

--- a/smoke_test/workers/test.js
+++ b/smoke_test/workers/test.js
@@ -20,11 +20,19 @@ async function main() {
         tunnelUrl = await ngrok.connect({
             proto: "http",
             addr: url.host,
+            authtoken: process.env.NGROK_AUTHTOKEN,
         });
-        console.info(`Established a localtunnel on ${tunnelUrl}`);
 
         clientUrlInsideWorker = new URL(tunnelUrl);
-        clientUrlInsideWorker.protocol = url.protocol;
+        if (url.protocol === "http:") {
+            clientUrlInsideWorker.protocol = "https:";
+        } else if (url.protocol === "ws:") {
+            clientUrlInsideWorker.protocol = "wss:";
+        } else {
+            clientUrlInsideWorker.protocol = url.protocol;
+        }
+
+        console.info(`Established a localtunnel on ${clientUrlInsideWorker}`);
     }
 
     let ok = false;


### PR DESCRIPTION
Some server implementations (including the Hrana test server v1) naively parse incoming statements to distinguish between INSERT/UPDATE/DELETE (which return no rows and set `rowsAffected`) and SELECT (which can return rows and does not set `rowsAffected`). But this does not work, because INSERT/UPDATE/DELETE can return rows with a RETURNING clause.

Also, these statements can contain a WITH clause, so the `INSERT`/`UPDATE`/`DELETE` keyword does not have to be the first token in the SQL string.