### PR TITLE
Introduce `TransactionMode`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Added `TransactionMode` argument to `batch()` and `transaction()` ([#46](https://github.com/libsql/libsql-client-ts/pull/46))
+- **Changed the default transaction mode** from `BEGIN DEFERRED` to `BEGIN IMMEDIATE`
+
 ## 0.2.0 -- 2023-06-07
 
 - **Added support for interactive transactions over HTTP** by using `@libsql/hrana-client` version 0.4 ([#44](https://github.com/libsql/libsql-client-ts/pull/44))

--- a/examples/src/example.ts
+++ b/examples/src/example.ts
@@ -6,7 +6,7 @@ async function example() {
     url
   };
   const db = createClient(config);
-  await db.batch([
+  await db.batch("write", [
     "CREATE TABLE IF NOT EXISTS users (email TEXT)",
     "INSERT INTO users (email) VALUES ('alice@example.com')",
     "INSERT INTO users (email) VALUES ('bob@example.com')"

--- a/smoke_test/workers/test.js
+++ b/smoke_test/workers/test.js
@@ -32,7 +32,7 @@ async function main() {
             clientUrlInsideWorker.protocol = url.protocol;
         }
 
-        console.info(`Established a localtunnel on ${clientUrlInsideWorker}`);
+        console.info(`Established an ngrok tunnel on ${clientUrlInsideWorker}`);
     }
 
     let ok = false;

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,8 +1,8 @@
 import type { Config } from "./api.js";
 import { LibsqlError } from "./api.js";
-import { supportedUrlLink } from "./help.js";
 import type { Authority } from "./uri.js";
 import { parseUri } from "./uri.js";
+import { supportedUrlLink } from "./util.js";
 
 export interface ExpandedConfig {
     scheme: ExpandedScheme;

--- a/src/help.ts
+++ b/src/help.ts
@@ -1,1 +1,0 @@
-export const supportedUrlLink = "https://github.com/libsql/libsql-client-ts#supported-urls";

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,34 @@
+import { TransactionMode, InStatement, LibsqlError } from "./api.js";
+
+export const supportedUrlLink = "https://github.com/libsql/libsql-client-ts#supported-urls";
+
+export function transactionModeToBegin(mode: TransactionMode): string {
+    if (mode === "write") {
+        return "BEGIN IMMEDIATE";
+    } else if (mode === "read") {
+        return "BEGIN TRANSACTION READONLY";
+    } else if (mode === "deferred") {
+        return "BEGIN DEFERRED";
+    } else {
+        throw RangeError('Unknown transaction mode, supported values are "write", "read" and "deferred"');
+    }
+}
+
+export type BatchArgs = {
+    mode: TransactionMode,
+    stmts: Array<InStatement>,
+};
+
+export function extractBatchArgs(arg1: unknown, arg2: unknown): BatchArgs {
+    if (arg2 === undefined) {
+        return {
+            mode: "write",
+            stmts: arg1 as Array<InStatement>,
+        };
+    } else {
+        return {
+            mode: arg1 as TransactionMode,
+            stmts: arg2 as Array<InStatement>,
+        };
+    }
+}

--- a/src/web.ts
+++ b/src/web.ts
@@ -2,7 +2,8 @@ import type { Config, Client } from "./api.js";
 import { LibsqlError } from "./api.js";
 import type { ExpandedConfig } from "./config.js";
 import { expandConfig } from "./config.js";
-import { supportedUrlLink } from "./help.js";
+import { supportedUrlLink } from "./util.js";
+
 import { _createClient as _createWsClient } from "./ws.js";
 import { _createClient as _createHttpClient } from "./http.js";
 


### PR DESCRIPTION
The client has been using `BEGIN DEFERRED` as the transaction mode, which is almost never the most useful option:
- For readonly transactions, it prevents them being executed on the replica
- For read-write transactions, it causes random transaction failures if there is a concurrent write transaction on the server.

This PR introduces `TransactionMode`, which allows the user to select one of these options:
- `"write"` does `BEGIN IMMEDIATE`, so that write transactions are serialized instead of aborted
- `"read"` does `BEGIN TRANSACTION READONLY`, so that sqld can optimize it as read-only (this syntax is not yet recognized and treated as `BEGIN DEFERRED` by sqld)
- `"deferred"` explicitly opts into `BEGIN DEFERRED`.