### PR TITLE
Add `ResultSet.toJSON()`

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -355,6 +355,12 @@ export interface ResultSet {
      * table.
      */
     lastInsertRowid: bigint | undefined;
+
+    /** Converts the result set to JSON.
+     *
+     * This is used automatically by `JSON.stringify()`, but you can also call it explicitly.
+     */
+    toJSON(): any;
 }
 
 /** Row returned from an SQL statement.

--- a/src/hrana.ts
+++ b/src/hrana.ts
@@ -2,7 +2,7 @@ import * as hrana from "@libsql/hrana-client";
 import type { InStatement, ResultSet, Transaction, TransactionMode } from "./api.js";
 import { LibsqlError } from "./api.js";
 import type { SqlCache } from "./sql_cache.js";
-import { transactionModeToBegin } from "./util.js";
+import { transactionModeToBegin, ResultSetImpl } from "./util.js";
 
 export abstract class HranaTransaction implements Transaction {
     #mode: TransactionMode;
@@ -316,13 +316,12 @@ export function stmtToHrana(stmt: InStatement): hrana.Stmt {
 }
 
 export function resultSetFromHrana(hranaRows: hrana.RowsResult): ResultSet {
-    return {
-        columns: hranaRows.columnNames.map(c => c ?? ""),
-        rows: hranaRows.rows,
-        rowsAffected: hranaRows.affectedRowCount,
-        lastInsertRowid: hranaRows.lastInsertRowid !== undefined
-            ? BigInt(hranaRows.lastInsertRowid) : undefined,
-    };
+    const columns = hranaRows.columnNames.map(c => c ?? "");
+    const rows = hranaRows.rows;
+    const rowsAffected = hranaRows.affectedRowCount;
+    const lastInsertRowid = hranaRows.lastInsertRowid !== undefined
+            ? BigInt(hranaRows.lastInsertRowid) : undefined;
+    return new ResultSetImpl(columns, rows, rowsAffected, lastInsertRowid);
 }
 
 export function mapHranaError(e: unknown): unknown {

--- a/src/sqlite3.ts
+++ b/src/sqlite3.ts
@@ -8,7 +8,7 @@ import type {
 import { LibsqlError } from "./api.js";
 import type { ExpandedConfig } from "./config.js";
 import { expandConfig } from "./config.js";
-import { supportedUrlLink, transactionModeToBegin } from "./util.js";
+import { supportedUrlLink, transactionModeToBegin, ResultSetImpl } from "./util.js";
 
 export * from "./api.js";
 
@@ -226,12 +226,12 @@ function executeStmt(db: Database.Database, stmt: InStatement, intMode: IntMode)
             // TODO: can we get this info from better-sqlite3?
             const rowsAffected = 0;
             const lastInsertRowid = undefined;
-            return { columns, rows, rowsAffected, lastInsertRowid };
+            return new ResultSetImpl(columns, rows, rowsAffected, lastInsertRowid);
         } else {
             const info = sqlStmt.run(args);
             const rowsAffected = info.changes;
             const lastInsertRowid = BigInt(info.lastInsertRowid);
-            return { columns: [], rows: [], rowsAffected, lastInsertRowid };
+            return new ResultSetImpl([], [], rowsAffected, lastInsertRowid);
         }
     } catch (e) {
         throw mapSqliteError(e);

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,4 +1,5 @@
-import { TransactionMode, InStatement, LibsqlError } from "./api.js";
+import { Base64 } from "js-base64";
+import { ResultSet, Row, Value, TransactionMode, InStatement, LibsqlError } from "./api.js";
 
 export const supportedUrlLink = "https://github.com/libsql/libsql-client-ts#supported-urls";
 
@@ -11,5 +12,47 @@ export function transactionModeToBegin(mode: TransactionMode): string {
         return "BEGIN DEFERRED";
     } else {
         throw RangeError('Unknown transaction mode, supported values are "write", "read" and "deferred"');
+    }
+}
+
+export class ResultSetImpl implements ResultSet {
+    columns: Array<string>;
+    rows: Array<Row>;
+    rowsAffected: number;
+    lastInsertRowid: bigint | undefined;
+
+    constructor(
+        columns: Array<string>,
+        rows: Array<Row>,
+        rowsAffected: number,
+        lastInsertRowid: bigint | undefined,
+    ) {
+        this.columns = columns;
+        this.rows = rows;
+        this.rowsAffected = rowsAffected;
+        this.lastInsertRowid = lastInsertRowid;
+    }
+
+    toJSON(): any {
+        return {
+            "columns": this.columns,
+            "rows": this.rows.map(rowToJson),
+            "rowsAffected": this.rowsAffected,
+            "lastInsertRowid": this.lastInsertRowid !== undefined ? ""+this.lastInsertRowid : null,
+        };
+    }
+}
+
+function rowToJson(row: Row): unknown {
+    return Array.prototype.map.call(row, valueToJson);
+}
+
+function valueToJson(value: Value): unknown {
+    if (typeof value === "bigint") {
+        return ""+value;
+    } else if (value instanceof ArrayBuffer) {
+        return Base64.fromUint8Array(new Uint8Array(value));
+    } else {
+        return value;
     }
 }


### PR DESCRIPTION
Fixes #58.

The implementation in this PR is lossy: bigints are converted to strings, and BLOBs are converted to base64-encoded strings.