### PR TITLE
Override the default import for supported edge runtimes

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,13 @@
     "exports": {
         ".": {
             "types": "./lib-esm/index.d.ts",
-            "import": "./lib-esm/index.js",
+            "import": {
+                "workerd": "./lib-esm/web.js",
+                "deno": "./lib-esm/web.js",
+                "edge-light": "./lib-esm/web.js",
+                "netlify": "./lib-esm/web.js",
+                "default": "./lib-esm/index.js"
+            },
             "require": "./lib-cjs/index.js"
         },
         "./http": {

--- a/smoke_test/vercel/app/api/function.ts
+++ b/smoke_test/vercel/app/api/function.ts
@@ -1,4 +1,4 @@
-import * as libsql from "@libsql/client/web";
+import * as libsql from "@libsql/client";
 
 export const config = {
     runtime: "edge",

--- a/smoke_test/workers/worker.js
+++ b/smoke_test/workers/worker.js
@@ -1,4 +1,4 @@
-import * as libsql from "@libsql/client/web";
+import * as libsql from "@libsql/client";
 
 export default {
     async fetch(request, env, ctx) {


### PR DESCRIPTION
The default import had included the Node.js-specific local sqlite3 client, so all developers on platforms other than Node.js needed to use a subpackage import such as `@libsql/client/web`.

This PR adds conditional imports to package.json that should allow the default import `@libsql/client` to work as `@libsql/client/web` in the edge runtimes that we support.

Fixes #55