### PR TITLE
Use Hrana 3 when available

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,30 +35,28 @@ jobs:
     - name: "Build"
       run: "npm run build"
 
-    - name: "Test Hrana 1 over WebSockets"
+    - name: "Test Hrana 1 over WebSocket"
       run: "python hrana-test-server/server_v1.py npm test"
-      env:
-        "URL": "ws://localhost:8080"
-        "SERVER": "test_v1"
-    - name: "Test Hrana 2 over WebSockets"
+      env: {"URL": "ws://localhost:8080", "SERVER": "test_v1"}
+    - name: "Test Hrana 2 over WebSocket"
       run: "python hrana-test-server/server_v2.py npm test"
-      env:
-        "URL": "ws://localhost:8080"
-        "SERVER": "test_v2"
+      env: {"URL": "ws://localhost:8080", "SERVER": "test_v2"}
     - name: "Test Hrana 2 over HTTP"
       run: "python hrana-test-server/server_v2.py npm test"
-      env:
-        "URL": "http://localhost:8080"
-        "SERVER": "test_v2"
+      env: {"URL": "http://localhost:8080", "SERVER": "test_v2"}
+    - name: "Test Hrana 3 over WebSocket"
+      run: "python hrana-test-server/server_v3.py npm test"
+      env: {"URL": "ws://localhost:8080", "SERVER": "test_v3"}
+    - name: "Test Hrana 3 over HTTP"
+      run: "python hrana-test-server/server_v3.py npm test"
+      env: {"URL": "http://localhost:8080", "SERVER": "test_v3"}
     - name: "Test local file"
       run: "npm test"
-      env:
-        "URL": "file:///tmp/test.db"
+      env: {"URL": "file:///tmp/test.db"}
 
     - name: "Test example"
       run: "node examples/example.js"
-      env:
-        "URL": "file:///tmp/example.db"
+      env: {"URL": "file:///tmp/example.db"}
 
   "workers-test":
     name: "Build and test with Cloudflare Workers"
@@ -95,37 +93,37 @@ jobs:
     - name: "Install npm dependencies of the Workers test"
       run: "cd smoke_test/workers && npm link ../.."
 
-    - name: "Local test with Hrana 1 over WebSockets"
+    - name: "Local test with Hrana 1 over WebSocket"
       run: "cd smoke_test/workers && python ../../hrana-test-server/server_v1.py node test.js"
-      env:
-        "LOCAL": "1"
-        "URL": "ws://localhost:8080"
-    - name: "Local test with Hrana 2 over WebSockets"
+      env: {"LOCAL": "1", "URL": "ws://localhost:8080"}
+    - name: "Local test with Hrana 2 over WebSocket"
       run: "cd smoke_test/workers && python ../../hrana-test-server/server_v2.py node test.js"
-      env:
-        "LOCAL": "1"
-        "URL": "ws://localhost:8080"
+      env: {"LOCAL": "1", "URL": "ws://localhost:8080"}
     - name: "Local test with Hrana 2 over HTTP"
       run: "cd smoke_test/workers && python ../../hrana-test-server/server_v2.py node test.js"
-      env:
-        "LOCAL": "1"
-        "URL": "http://localhost:8080"
+      env: {"LOCAL": "1", "URL": "http://localhost:8080"}
+    - name: "Local test with Hrana 3 over WebSocket"
+      run: "cd smoke_test/workers && python ../../hrana-test-server/server_v3.py node test.js"
+      env: {"LOCAL": "1", "URL": "ws://localhost:8080"}
+    - name: "Local test with Hrana 3 over HTTP"
+      run: "cd smoke_test/workers && python ../../hrana-test-server/server_v3.py node test.js"
+      env: {"LOCAL": "1", "URL": "http://localhost:8080"}
 
-    - name: "Non-local test with Hrana 1 over WebSockets"
+    - name: "Non-local test with Hrana 1 over WebSocket"
       run: "cd smoke_test/workers && python ../../hrana-test-server/server_v1.py node test.js"
-      env:
-        "LOCAL": "0"
-        "URL": "ws://localhost:8080"
-    - name: "Non-local test with Hrana 2 over WebSockets"
+      env: {"LOCAL": "0", "URL": "ws://localhost:8080"}
+    - name: "Non-local test with Hrana 2 over WebSocket"
       run: "cd smoke_test/workers && python ../../hrana-test-server/server_v2.py node test.js"
-      env:
-        "LOCAL": "0"
-        "URL": "ws://localhost:8080"
+      env: {"LOCAL": "0", "URL": "ws://localhost:8080"}
     - name: "Non-local test with Hrana 2 over HTTP"
       run: "cd smoke_test/workers && python ../../hrana-test-server/server_v2.py node test.js"
-      env:
-        "LOCAL": "0"
-        "URL": "http://localhost:8080"
+      env: {"LOCAL": "0", "URL": "http://localhost:8080"}
+    - name: "Non-local test with Hrana 3 over WebSocket"
+      run: "cd smoke_test/workers && python ../../hrana-test-server/server_v3.py node test.js"
+      env: {"LOCAL": "0", "URL": "ws://localhost:8080"}
+    - name: "Non-local test with Hrana 3 over HTTP"
+      run: "cd smoke_test/workers && python ../../hrana-test-server/server_v3.py node test.js"
+      env: {"LOCAL": "0", "URL": "http://localhost:8080"}
 
   "vercel-test":
     name: "Build and test with Vercel Edge Functions"
@@ -162,15 +160,18 @@ jobs:
     - name: "Install npm dependencies of the Vercel test"
       run: "cd smoke_test/vercel && npm install"
 
-    - name: "Test with Hrana 1 over WebSockets"
+    - name: "Test with Hrana 1 over WebSocket"
       run: "cd smoke_test/vercel && python ../../hrana-test-server/server_v1.py node test.js"
-      env:
-        "URL": "ws://localhost:8080"
-    - name: "Test with Hrana 2 over WebSockets"
+      env: {"URL": "ws://localhost:8080"}
+    - name: "Test with Hrana 2 over WebSocket"
       run: "cd smoke_test/vercel && python ../../hrana-test-server/server_v2.py node test.js"
-      env:
-        "URL": "ws://localhost:8080"
+      env: {"URL": "ws://localhost:8080"}
     - name: "Test with Hrana 2 over HTTP"
       run: "cd smoke_test/vercel && python ../../hrana-test-server/server_v2.py node test.js"
-      env:
-        "URL": "http://localhost:8080"
+      env: {"URL": "http://localhost:8080"}
+    - name: "Test with Hrana 3 over WebSocket"
+      run: "cd smoke_test/vercel && python ../../hrana-test-server/server_v3.py node test.js"
+      env: {"URL": "ws://localhost:8080"}
+    - name: "Test with Hrana 3 over HTTP"
+      run: "cd smoke_test/vercel && python ../../hrana-test-server/server_v3.py node test.js"
+      env: {"URL": "http://localhost:8080"}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,6 +8,7 @@ jobs:
   "node-test":
     name: "Build and test on Node.js"
     runs-on: ubuntu-latest
+    env: {"NODE_OPTIONS": "--trace-warnings"}
     steps:
     - name: "Checkout this repo"
       uses: actions/checkout@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,7 +71,7 @@ jobs:
     - name: "Setup Node.js"
       uses: actions/setup-node@v3
       with:
-        node-version: "19.x"
+        node-version: "lts/Hydrogen"
         cache: "npm"
     - name: "Install npm dependencies"
       run: "npm ci"
@@ -138,7 +138,7 @@ jobs:
     - name: "Setup Node.js"
       uses: actions/setup-node@v3
       with:
-        node-version: "19.x"
+        node-version: "lts/Hydrogen"
         cache: "npm"
     - name: "Install npm dependencies"
       run: "npm ci"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Updated `@libsql/hrana-client` to version 0.5.0, which implements Hrana 3
+
 ## 0.3.1 -- 2023-07-20
 
 - Added `ResultSet.toJSON()` to provide better JSON serialization. ([#61](https://github.com/libsql/libsql-client-ts/pull/61))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Updated `@libsql/hrana-client` to version 0.5.0, which implements Hrana 3
+    - Dropped workarounds for broken WebSocket support in Miniflare 2
 
 ## 0.3.1 -- 2023-07-20
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "0.3.2-pre",
             "license": "MIT",
             "dependencies": {
-                "@libsql/hrana-client": "^0.5.0-pre.0",
+                "@libsql/hrana-client": "^0.5.0-pre.1",
                 "better-sqlite3": "^8.0.1",
                 "js-base64": "^3.7.5"
             },
@@ -953,9 +953,9 @@
             "dev": true
         },
         "node_modules/@libsql/hrana-client": {
-            "version": "0.5.0-pre.0",
-            "resolved": "https://registry.npmjs.org/@libsql/hrana-client/-/hrana-client-0.5.0-pre.0.tgz",
-            "integrity": "sha512-5WnSQMT6AeDHdmLFu1M7ANlwk+m/jZRjzn3fkC+Lt6UssQ76EmW11cLiAIfVDeXlS4temwQkjpuUGQ37FSeMFg==",
+            "version": "0.5.0-pre.1",
+            "resolved": "https://registry.npmjs.org/@libsql/hrana-client/-/hrana-client-0.5.0-pre.1.tgz",
+            "integrity": "sha512-0QFRROwq4z0QA2/A+Cje52TvogIKf1c76J2B6q74f8+T3G1rKjSu8vacLf7HTr5HNBdaJtbG7NrY5hi1S/lRZg==",
             "dependencies": {
                 "@libsql/isomorphic-fetch": "^0.1.6",
                 "@libsql/isomorphic-ws": "^0.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "0.3.2-pre",
             "license": "MIT",
             "dependencies": {
-                "@libsql/hrana-client": "^0.4.3",
+                "@libsql/hrana-client": "^0.5.0-pre.0",
                 "better-sqlite3": "^8.0.1",
                 "js-base64": "^3.7.5"
             },
@@ -953,22 +953,22 @@
             "dev": true
         },
         "node_modules/@libsql/hrana-client": {
-            "version": "0.4.3",
-            "resolved": "https://registry.npmjs.org/@libsql/hrana-client/-/hrana-client-0.4.3.tgz",
-            "integrity": "sha512-ZlAXy3PpB8B93iu8MyDyMpzbu1b4G4oa5KOjbABHe7iBybx7yC+t3U/sK7c37QsmpRZQXi0S+vNPpGTlje3bCA==",
+            "version": "0.5.0-pre.0",
+            "resolved": "https://registry.npmjs.org/@libsql/hrana-client/-/hrana-client-0.5.0-pre.0.tgz",
+            "integrity": "sha512-5WnSQMT6AeDHdmLFu1M7ANlwk+m/jZRjzn3fkC+Lt6UssQ76EmW11cLiAIfVDeXlS4temwQkjpuUGQ37FSeMFg==",
             "dependencies": {
-                "@libsql/isomorphic-fetch": "^0.1.1",
-                "@libsql/isomorphic-ws": "^0.1.2",
+                "@libsql/isomorphic-fetch": "^0.1.6",
+                "@libsql/isomorphic-ws": "^0.1.3",
                 "js-base64": "^3.7.5"
             }
         },
         "node_modules/@libsql/isomorphic-fetch": {
-            "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/@libsql/isomorphic-fetch/-/isomorphic-fetch-0.1.4.tgz",
-            "integrity": "sha512-eRgV4b1d6RVLciafGEKZghDOvrQ7fDuPgfGzelsfPz1HxFERaTQuOwL5FthZcKBtHI6Wqu5zmhUu5bREZr1mpA==",
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/@libsql/isomorphic-fetch/-/isomorphic-fetch-0.1.6.tgz",
+            "integrity": "sha512-8qhxEDmVBDb54E9xdW1xqw3zLNShkMZpf5YQU3PvwjtKNLOPde59Oqez+RnZHsYkt9zQxxOF+7gSHVJeP/UWqg==",
             "dependencies": {
                 "@types/node-fetch": "^2.2.6",
-                "node-fetch": "^2.2.6"
+                "node-fetch": "^2.6.12"
             }
         },
         "node_modules/@libsql/isomorphic-ws": {
@@ -3148,9 +3148,9 @@
             "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         },
         "node_modules/node-fetch": {
-            "version": "2.6.11",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.11.tgz",
-            "integrity": "sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==",
+            "version": "2.6.12",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.12.tgz",
+            "integrity": "sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==",
             "dependencies": {
                 "whatwg-url": "^5.0.0"
             },

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "0.3.2-pre",
             "license": "MIT",
             "dependencies": {
-                "@libsql/hrana-client": "^0.5.0-pre.1",
+                "@libsql/hrana-client": "^0.5.0-pre.2",
                 "better-sqlite3": "^8.0.1",
                 "js-base64": "^3.7.5"
             },
@@ -953,9 +953,9 @@
             "dev": true
         },
         "node_modules/@libsql/hrana-client": {
-            "version": "0.5.0-pre.1",
-            "resolved": "https://registry.npmjs.org/@libsql/hrana-client/-/hrana-client-0.5.0-pre.1.tgz",
-            "integrity": "sha512-0QFRROwq4z0QA2/A+Cje52TvogIKf1c76J2B6q74f8+T3G1rKjSu8vacLf7HTr5HNBdaJtbG7NrY5hi1S/lRZg==",
+            "version": "0.5.0-pre.2",
+            "resolved": "https://registry.npmjs.org/@libsql/hrana-client/-/hrana-client-0.5.0-pre.2.tgz",
+            "integrity": "sha512-1QOfsy093aar+Mi9Kyh85qkmvIJz3bQTg4nN2kBtQBZWzWgjYu/Q2fywfJzvDbR+CwS+Pqapz4y4aAtzkCoBuQ==",
             "dependencies": {
                 "@libsql/isomorphic-fetch": "^0.1.6",
                 "@libsql/isomorphic-ws": "^0.1.3",

--- a/package.json
+++ b/package.json
@@ -83,6 +83,11 @@
         "typedoc": "rm -rf ./docs && typedoc"
     },
 
+    "dependencies": {
+        "@libsql/hrana-client": "^0.5.0-pre.0",
+        "better-sqlite3": "^8.0.1",
+        "js-base64": "^3.7.5"
+    },
     "devDependencies": {
         "@types/better-sqlite3": "^7.6.3",
         "@types/jest": "^29.2.5",
@@ -91,10 +96,5 @@
         "ts-jest": "^29.0.5",
         "typedoc": "^0.23.28",
         "typescript": "^4.9.4"
-    },
-    "dependencies": {
-        "@libsql/hrana-client": "^0.4.3",
-        "better-sqlite3": "^8.0.1",
-        "js-base64": "^3.7.5"
     }
 }

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     },
 
     "dependencies": {
-        "@libsql/hrana-client": "^0.5.0-pre.1",
+        "@libsql/hrana-client": "^0.5.0-pre.2",
         "better-sqlite3": "^8.0.1",
         "js-base64": "^3.7.5"
     },

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     },
 
     "dependencies": {
-        "@libsql/hrana-client": "^0.5.0-pre.0",
+        "@libsql/hrana-client": "^0.5.0-pre.1",
         "better-sqlite3": "^8.0.1",
         "js-base64": "^3.7.5"
     },

--- a/smoke_test/vercel/test.js
+++ b/smoke_test/vercel/test.js
@@ -1,3 +1,4 @@
+"use strict";
 const { spawn } = require("node:child_process");
 const fs = require("node:fs");
 const fetch = require("node-fetch");
@@ -122,10 +123,13 @@ async function main() {
     console.info(`Creating a tunnel to ${url}...`);
     const tunnel = await localtunnel({
         port: url.port,
-        local_host: url.hostname,
+        // NOTE: if we specify `local_host`, `localtunnel` will try to rewrite the `Host` header in the
+        // tunnelled HTTP requests. Unfortunately, they do it in a very silly way by converting the
+        // tunnelled data to a string, thus corrupting the request body.
+        //local_host: url.hostname,
     });
 
-    clientUrlInsideVercel = new URL(tunnel.url);
+    let clientUrlInsideVercel = new URL(tunnel.url);
     if (url.protocol === "http:") {
         clientUrlInsideVercel.protocol = "https:";
     } else if (url.protocol === "ws:") {

--- a/smoke_test/workers/package.json
+++ b/smoke_test/workers/package.json
@@ -1,6 +1,6 @@
 {
     "devDependencies": {
         "localtunnel": "^2.0.2",
-        "wrangler": "^2.20.0"
+        "wrangler": "^3.5.1"
     }
 }

--- a/smoke_test/workers/test.js
+++ b/smoke_test/workers/test.js
@@ -1,3 +1,4 @@
+"use strict";
 const localtunnel = require("localtunnel");
 const wrangler = require("wrangler");
 
@@ -15,7 +16,10 @@ async function main() {
         console.info(`Creating an tunnel to ${url}...`);
         tunnel = await localtunnel({
             port: url.port,
-            local_host: url.hostname,
+            // NOTE: if we specify `local_host`, `localtunnel` will try to rewrite the `Host` header in the
+            // tunnelled HTTP requests. Unfortunately, they do it in a very silly way by converting the
+            // tunnelled data to a string, thus corrupting the request body.
+            //local_host: url.hostname,
         });
 
         clientUrlInsideWorker = new URL(tunnel.url);

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -1,7 +1,8 @@
 import { expect } from "@jest/globals";
 import type { MatcherFunction } from "expect";
-import type { Request, Response } from "@libsql/isomorphic-fetch";
-import { fetch } from "@libsql/isomorphic-fetch";
+
+import type { Request, Response } from "@libsql/hrana-client";
+import { fetch } from "@libsql/hrana-client";
 
 import "./helpers.js";
 
@@ -875,7 +876,7 @@ describe("transaction()", () => {
         test(`${title} in transaction()`, withClient(async (c) => {
             const txn = await c.transaction("read");
             await expect(txn.execute(sql)).rejects.toBeLibsqlError("HRANA_WEBSOCKET_ERROR");
-            await expect(txn.commit()).rejects.toBeLibsqlError("HRANA_WEBSOCKET_ERROR");
+            await expect(txn.commit()).rejects.toBeLibsqlError("TRANSACTION_CLOSED");
             txn.close();
 
             expect((await c.execute("SELECT 42")).rows[0][0]).toStrictEqual(42);

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -1,6 +1,7 @@
 import { expect } from "@jest/globals";
 import type { MatcherFunction } from "expect";
-import { fetch, Request, Response } from "@libsql/isomorphic-fetch";
+import type { Request, Response } from "@libsql/isomorphic-fetch";
+import { fetch } from "@libsql/isomorphic-fetch";
 
 import "./helpers.js";
 
@@ -17,10 +18,15 @@ const isHttp = config.url.startsWith("http:") || config.url.startsWith("https:")
 const isFile = config.url.startsWith("file:");
 
 // This allows us to skip tests based on the Hrana server that we are targeting:
+// - "test_v3" is the v3 test server in Python
 // - "test_v2" is the v2 test server in Python
 // - "test_v1" is the v1 test server in Python
 // - "sqld" is sqld
-const server = process.env.SERVER ?? "test_v2";
+const server = process.env.SERVER ?? "test_v3";
+
+const hasHrana2 = server !== "test_v1";
+const hasHrana3 = server !== "test_v1" && server !== "test_v2";
+const hasNetworkErrors = isWs && (server === "test_v1" || server === "test_v2" || server === "test_v3");
 
 function withClient(
     f: (c: libsql.Client) => Promise<void>,
@@ -161,7 +167,7 @@ describe("execute()", () => {
         expect(Array.from(rs.rows[0])).toStrictEqual([42, "foo"]);
     }));
 
-    (server != "test_v1" ? test : test.skip)("rowsAffected with WITH INSERT", withClient(async (c) => {
+    (hasHrana2 ? test : test.skip)("rowsAffected with WITH INSERT", withClient(async (c) => {
         await c.batch([
             "DROP TABLE IF EXISTS t",
             "CREATE TABLE t (a)",
@@ -525,7 +531,7 @@ describe("batch()", () => {
         expect(Array.from(rs3.rows[0])).toStrictEqual([42]);
     }));
 
-    test.skip("ROLLBACK statement stops execution of batch", withClient(async (c) => {
+    (hasHrana3 ? test : test.skip)("ROLLBACK statement stops execution of batch", withClient(async (c) => {
         await c.execute("DROP TABLE IF EXISTS t");
         await c.execute("CREATE TABLE t (a)");
 
@@ -624,7 +630,10 @@ describe("transaction()", () => {
         expect(rs.rows[0][0]).toStrictEqual(1);
     }));
 
-    test.skip("ROLLBACK statement stops execution of transaction", withClient(async (c) => {
+    (hasHrana3 ? test : test.skip)(
+        "ROLLBACK statement stops execution of transaction",
+        withClient(async (c) =>
+    {
         await c.execute("DROP TABLE IF EXISTS t");
         await c.execute("CREATE TABLE t (a)");
 
@@ -634,16 +643,19 @@ describe("transaction()", () => {
         const prom3 = txn.execute("INSERT INTO t VALUES (4), (5)");
 
         await prom1;
-        await expect(prom2).rejects.toBeLibsqlError("TRANSACTION_CLOSED");
+        await prom2;
         await expect(prom3).rejects.toBeLibsqlError("TRANSACTION_CLOSED");
-        await expect((async () => txn.commit())()).rejects.toBeLibsqlError("TRANSACTION_CLOSED");
+        await expect(txn.commit()).rejects.toBeLibsqlError();
         txn.close();
 
         const rs = await c.execute("SELECT COUNT(*) FROM t");
         expect(rs.rows[0][0]).toStrictEqual(0);
     }));
 
-    test.skip("OR ROLLBACK statement stops execution of transaction", withClient(async (c) => {
+    (hasHrana3 ? test : test.skip)(
+        "OR ROLLBACK statement stops execution of transaction",
+        withClient(async (c) =>
+    {
         await c.execute("DROP TABLE IF EXISTS t");
         await c.execute("CREATE TABLE t (a UNIQUE)");
 
@@ -655,14 +667,17 @@ describe("transaction()", () => {
         await prom1;
         await expect(prom2).rejects.toBeLibsqlError();
         await expect(prom3).rejects.toBeLibsqlError("TRANSACTION_CLOSED");
-        await expect((async () => txn.commit())()).rejects.toBeLibsqlError("TRANSACTION_CLOSED");
+        await expect(txn.commit()).rejects.toBeLibsqlError();
         txn.close();
 
         const rs = await c.execute("SELECT COUNT(*) FROM t");
         expect(rs.rows[0][0]).toStrictEqual(0);
     }));
 
-    test.skip("OR ROLLBACK as the first statement stops execution of transaction", withClient(async (c) => {
+    (hasHrana3 ? test : test.skip)(
+        "OR ROLLBACK as the first statement stops execution of transaction",
+        withClient(async (c) => 
+    {
         await c.execute("DROP TABLE IF EXISTS t");
         await c.execute("CREATE TABLE t (a UNIQUE)");
         await c.execute("INSERT INTO t VALUES (1), (2), (3)");
@@ -673,7 +688,7 @@ describe("transaction()", () => {
 
         await expect(prom1).rejects.toBeLibsqlError();
         await expect(prom2).rejects.toBeLibsqlError("TRANSACTION_CLOSED");
-        await expect((async () => txn.commit())()).rejects.toBeLibsqlError("TRANSACTION_CLOSED");
+        await expect(txn.commit()).rejects.toBeLibsqlError();
         txn.close();
 
         const rs = await c.execute("SELECT COUNT(*) FROM t");
@@ -741,7 +756,7 @@ describe("transaction()", () => {
         }));
     });
 
-    (server !== "test_v1" ? describe : describe.skip)("executeMultiple()", () => {
+    (hasHrana2 ? describe : describe.skip)("executeMultiple()", () => {
         test("as the first operation on transaction", withClient(async (c) => {
             const txn = await c.transaction("write");
 
@@ -788,7 +803,7 @@ describe("transaction()", () => {
     });
 });
 
-(server !== "test_v1" ? describe : describe.skip)("executeMultiple()", () => {
+(hasHrana2 ? describe : describe.skip)("executeMultiple()", () => {
     test("multiple statements", withClient(async (c) => {
         await c.executeMultiple(`
             DROP TABLE IF EXISTS t;
@@ -844,7 +859,6 @@ describe("transaction()", () => {
     }));
 });
 
-const hasNetworkErrors = isWs && (server == "test_v1" || server == "test_v2");
 (hasNetworkErrors ? describe : describe.skip)("network errors", () => {
     const testCases = [
         {title: "WebSocket close", sql: ".close_ws"},
@@ -879,7 +893,6 @@ const hasNetworkErrors = isWs && (server == "test_v1" || server == "test_v2");
 (isHttp ? test : test.skip)("custom fetch", async () => {
     let fetchCalledCount = 0;
     function customFetch(request: Request): Promise<Response> {
-        expect(request).toBeInstanceOf(Request);
         fetchCalledCount += 1;
         return fetch(request);
     }
@@ -888,7 +901,7 @@ const hasNetworkErrors = isWs && (server == "test_v1" || server == "test_v2");
     try {
         const rs = await c.execute("SELECT 42");
         expect(rs.rows[0][0]).toStrictEqual(42);
-        expect(fetchCalledCount).toStrictEqual(1);
+        expect(fetchCalledCount).toBeGreaterThan(0);
     } finally {
         c.close();
     }

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -1,3 +1,4 @@
+import console from "node:console";
 import { expect } from "@jest/globals";
 import type { MatcherFunction } from "expect";
 

--- a/src/hrana.ts
+++ b/src/hrana.ts
@@ -6,13 +6,15 @@ import { transactionModeToBegin, ResultSetImpl } from "./util.js";
 
 export abstract class HranaTransaction implements Transaction {
     #mode: TransactionMode;
+    #version: hrana.ProtocolVersion;
     // Promise that is resolved when the BEGIN statement completes, or `undefined` if we haven't executed the
     // BEGIN statement yet.
     #started: Promise<void> | undefined;
 
     /** @private */
-    constructor(mode: TransactionMode) {
+    constructor(mode: TransactionMode, version: hrana.ProtocolVersion) {
         this.#mode = mode;
+        this.#version = version;
         this.#started = undefined;
     }
 
@@ -24,34 +26,47 @@ export abstract class HranaTransaction implements Transaction {
     abstract close(): void;
     abstract get closed(): boolean;
 
-    async execute(stmt: InStatement): Promise<ResultSet> {
+    execute(stmt: InStatement): Promise<ResultSet> {
+        return this.batch([stmt]).then((results) => results[0]);
+    }
+
+    async batch(stmts: Array<InStatement>): Promise<Array<ResultSet>> {
         const stream = this._getStream();
         if (stream.closed) {
             throw new LibsqlError(
-                "Cannot execute a statement because the transaction is closed",
+                "Cannot execute statements because the transaction is closed",
                 "TRANSACTION_CLOSED",
             );
         }
 
         try {
-            const hranaStmt = stmtToHrana(stmt);
+            const hranaStmts = stmts.map(stmtToHrana);
 
-            let rowsPromise: Promise<hrana.RowsResult>;
+            let rowsPromises: Array<Promise<hrana.RowsResult | undefined>>;
             if (this.#started === undefined) {
                 // The transaction hasn't started yet, so we need to send the BEGIN statement in a batch with
-                // `stmt`.
+                // `hranaStmts`.
 
-                this._getSqlCache().apply([hranaStmt]);
+                this._getSqlCache().apply(hranaStmts);
                 const batch = stream.batch();
                 const beginStep = batch.step();
                 const beginPromise = beginStep.run(transactionModeToBegin(this.#mode));
 
-                // Execute the `stmt` only if the BEGIN succeeded, to make sure that we don't execute it
+                // Execute the `hranaStmts` only if the BEGIN succeeded, to make sure that we don't execute it
                 // outside of a transaction.
-                rowsPromise = batch.step()
-                    .condition(hrana.BatchCond.ok(beginStep))
-                    .query(hranaStmt)
-                    .then((result) => result!);
+                let lastStep = beginStep;
+                rowsPromises = hranaStmts.map((hranaStmt) => {
+                    const stmtStep = batch.step()
+                        .condition(hrana.BatchCond.ok(lastStep));
+                    if (this.#version >= 3) {
+                        // If the Hrana version supports it, make sure that we are still in a transaction
+                        stmtStep.condition(hrana.BatchCond.not(hrana.BatchCond.isAutocommit(batch)));
+                    }
+
+                    const rowsPromise = stmtStep.query(hranaStmt);
+                    lastStep = stmtStep;
+                    return rowsPromise;
+                });
 
                 // `this.#started` is resolved successfully only if the batch and the BEGIN statement inside
                 // of the batch are both successful.
@@ -63,67 +78,20 @@ export abstract class HranaTransaction implements Transaction {
                     await this.#started;
                 } catch (e) {
                     // If the BEGIN failed, the transaction is unusable and we must close it. However, if the
-                    // BEGIN suceeds and `stmt` fails, the transaction is _not_ closed.
+                    // BEGIN suceeds and `hranaStmts` fail, the transaction is _not_ closed.
                     this.close();
                     throw e;
                 }
             } else {
-                // The transaction has started, so we must wait until the BEGIN statement completed to make
-                // sure that we don't execute `stmt` outside of a transaction.
-                await this.#started;
-
-                this._getSqlCache().apply([hranaStmt]);
-                rowsPromise = stream.query(hranaStmt);
-            }
-
-            return resultSetFromHrana(await rowsPromise);
-        } catch (e) {
-            throw mapHranaError(e);
-        }
-    }
-
-    async batch(stmts: Array<InStatement>): Promise<Array<ResultSet>> {
-        const stream = this._getStream();
-        if (stream.closed) {
-            throw new LibsqlError(
-                "Cannot execute a batch because the transaction is closed",
-                "TRANSACTION_CLOSED",
-            );
-        }
-
-        try {
-            const hranaStmts = stmts.map(stmtToHrana);
-
-            // This is analogous to `execute()`, please read the comments there
-
-            let rowsPromises: Array<Promise<hrana.RowsResult | undefined>>;
-            if (this.#started === undefined) {
-                this._getSqlCache().apply(hranaStmts);
-                const batch = stream.batch();
-                const beginStep = batch.step();
-                const beginPromise = beginStep.run(transactionModeToBegin(this.#mode));
-
-                let lastStep = beginStep;
-                rowsPromises = hranaStmts.map((hranaStmt) => {
-                    const stmtStep = batch.step()
-                        .condition(hrana.BatchCond.ok(lastStep));
-                    const rowsPromise = stmtStep.query(hranaStmt);
-                    lastStep = stmtStep;
-                    return rowsPromise;
-                });
-
-                this.#started = batch.execute()
-                    .then(() => beginPromise)
-                    .then(() => undefined);
-
-                try {
+                if (this.#version < 3) {
+                    // The transaction has started, so we must wait until the BEGIN statement completed to make
+                    // sure that we don't execute `hranaStmts` outside of a transaction.
                     await this.#started;
-                } catch (e) {
-                    this.close();
-                    throw e;
+                } else {
+                    // The transaction has started, but we will use `hrana.BatchCond.isAutocommit()` to make
+                    // sure that we don't execute `hranaStmts` outside of a transaction, so we don't have to
+                    // wait for `this.#started`
                 }
-            } else {
-                await this.#started;
 
                 this._getSqlCache().apply(hranaStmts);
                 const batch = stream.batch();
@@ -133,6 +101,9 @@ export abstract class HranaTransaction implements Transaction {
                     const stmtStep = batch.step();
                     if (lastStep !== undefined) {
                         stmtStep.condition(hrana.BatchCond.ok(lastStep));
+                    }
+                    if (this.#version >= 3) {
+                        stmtStep.condition(hrana.BatchCond.not(hrana.BatchCond.isAutocommit(batch)));
                     }
                     const rowsPromise = stmtStep.query(hranaStmt);
                     lastStep = stmtStep;
@@ -147,8 +118,9 @@ export abstract class HranaTransaction implements Transaction {
                 const rows = await rowsPromise;
                 if (rows === undefined) {
                     throw new LibsqlError(
-                        "Server did not return a result for statement in a batch",
-                        "SERVER_ERROR",
+                        "Statement in a transaction was not executed, " +
+                            "probably because the transaction has been rolled back",
+                        "TRANSACTION_CLOSED",
                     );
                 }
                 resultSets.push(resultSetFromHrana(rows));
@@ -255,6 +227,7 @@ export abstract class HranaTransaction implements Transaction {
 
 export async function executeHranaBatch(
     mode: TransactionMode,
+    version: hrana.ProtocolVersion,
     batch: hrana.Batch,
     hranaStmts: Array<hrana.Stmt>,
 ): Promise<Array<ResultSet>> {
@@ -265,14 +238,20 @@ export async function executeHranaBatch(
     const stmtPromises = hranaStmts.map((hranaStmt) => {
         const stmtStep = batch.step()
             .condition(hrana.BatchCond.ok(lastStep));
-        const stmtPromise = stmtStep.query(hranaStmt);
+        if (version >= 3) {
+            stmtStep.condition(hrana.BatchCond.not(hrana.BatchCond.isAutocommit(batch)));
+        }
 
+        const stmtPromise = stmtStep.query(hranaStmt);
         lastStep = stmtStep;
         return stmtPromise;
     });
 
     const commitStep = batch.step()
         .condition(hrana.BatchCond.ok(lastStep));
+    if (version >= 3) {
+        commitStep.condition(hrana.BatchCond.not(hrana.BatchCond.isAutocommit(batch)));
+    }
     const commitPromise = commitStep.run("COMMIT");
 
     const rollbackStep = batch.step()
@@ -287,8 +266,8 @@ export async function executeHranaBatch(
         const hranaRows = await stmtPromise;
         if (hranaRows === undefined) {
             throw new LibsqlError(
-                "Server did not return a result for statement in a batch",
-                "SERVER_ERROR",
+                "Statement in a batch was not executed, probably because the transaction has been rolled back",
+                "TRANSACTION_CLOSED",
             );
         }
         resultSets.push(resultSetFromHrana(hranaRows));
@@ -320,7 +299,7 @@ export function resultSetFromHrana(hranaRows: hrana.RowsResult): ResultSet {
     const rows = hranaRows.rows;
     const rowsAffected = hranaRows.affectedRowCount;
     const lastInsertRowid = hranaRows.lastInsertRowid !== undefined
-            ? BigInt(hranaRows.lastInsertRowid) : undefined;
+            ? hranaRows.lastInsertRowid : undefined;
     return new ResultSetImpl(columns, rows, rowsAffected, lastInsertRowid);
 }
 
@@ -339,6 +318,8 @@ export function mapHranaError(e: unknown): unknown {
             code = "SERVER_ERROR";
         } else if (e instanceof hrana.ProtocolVersionError) {
             code = "PROTOCOL_VERSION_ERROR";
+        } else if (e instanceof hrana.InternalError) {
+            code = "INTERNAL_ERROR";
         }
         return new LibsqlError(e.message, code, e);
     }

--- a/src/http.ts
+++ b/src/http.ts
@@ -68,7 +68,7 @@ export class HttpClient implements Client {
             try {
                 rowsPromise = stream.query(hranaStmt);
             } finally {
-                stream.close();
+                stream.closeGracefully();
             }
 
             return resultSetFromHrana(await rowsPromise);
@@ -92,10 +92,14 @@ export class HttpClient implements Client {
                 const sqlCache = new SqlCache(stream, sqlCacheCapacity);
                 sqlCache.apply(hranaStmts);
 
-                const batch = stream.batch();
+                // TODO: we do not use a cursor here, because it would cause three roundtrips:
+                // 1. pipeline request to store SQL texts
+                // 2. cursor request
+                // 3. pipeline request to close the stream
+                const batch = stream.batch(false);
                 resultsPromise = executeHranaBatch(mode, version, batch, hranaStmts);
             } finally {
-                stream.close();
+                stream.closeGracefully();
             }
 
             return await resultsPromise;
@@ -122,7 +126,7 @@ export class HttpClient implements Client {
             try {
                 promise = stream.sequence(sql);
             } finally {
-                stream.close();
+                stream.closeGracefully();
             }
 
             await promise;

--- a/src/ws.ts
+++ b/src/ws.ts
@@ -114,7 +114,7 @@ export class WsClient implements Client {
             // network roundtrip.
             streamState.conn.sqlCache.apply([hranaStmt]);
             const hranaRowsPromise = streamState.stream.query(hranaStmt);
-            streamState.stream.close();
+            streamState.stream.closeGracefully();
 
             return resultSetFromHrana(await hranaRowsPromise);
         } catch (e) {
@@ -133,9 +133,8 @@ export class WsClient implements Client {
             // Schedule all operations synchronously, so they will be pipelined and executed in a single
             // network roundtrip.
             streamState.conn.sqlCache.apply(hranaStmts);
-            const batch = streamState.stream.batch();
+            const batch = streamState.stream.batch(version >= 3);
             const resultsPromise = executeHranaBatch(mode, version, batch, hranaStmts);
-            streamState.stream.close();
 
             return await resultsPromise;
         } catch (e) {
@@ -164,7 +163,7 @@ export class WsClient implements Client {
             // Schedule all operations synchronously, so they will be pipelined and executed in a single
             // network roundtrip.
             const promise = streamState.stream.sequence(sql);
-            streamState.stream.close();
+            streamState.stream.closeGracefully();
 
             await promise;
         } catch (e) {


### PR DESCRIPTION
Upgrade to `@libsql/hrana-client` version 0.5 to transparently use Hrana 3 if the server supports it. This allows us to fix a hole in the `transaction()` and `batch()` APIs: previously, if the transaction was rolled back using `ROLLBACK` or using the `OR ROLLBACK` conflict resolution strategy, the following statements would be executed outside of a transaction. With Hrana 3, we can use `hrana.BatchCond.isAutocommit()` to fix this.

The Hrana client will also internally use cursors (streaming) to implement batches. This means that the server does not have load the full result set into memory before sending it, which reduces memory pressure. However, the client API is unchanged, so the client will still keep all results in memory.