### PR TITLE
Update sqlite3.ts

### DIFF
--- a/src/sqlite3.ts
+++ b/src/sqlite3.ts
@@ -315,7 +315,7 @@ function valueToSql(value: InValue): unknown {
         }
         return value;
     } else if (typeof value === "boolean") {
-        return value ? 1n : 0n;
+        return value ? 1 : 0;
     } else if (value instanceof ArrayBuffer) {
         return Buffer.from(value);
     } else if (value instanceof Date) {


### PR DESCRIPTION
`1n and 0n` were causing error:
`RangeError: Loss of precision reading BigInt (0)`

This resolved it:
```
else if (typeof value === "boolean") {
        return value ? 1 : 0;
    }
 ```

Was there a special intention to convert a boolean to a bigint?  If not or if this was in error, it seems like this resolves and simplifies this part.

Thank you for all of your time and energy into this wonderful library.

🤍🙏🏼🌹⚡️✨ 