### PR TITLE
Add `rawCode` property to the errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
             "dependencies": {
                 "@libsql/hrana-client": "^0.5.5",
                 "js-base64": "^3.7.5",
-                "libsql": "^0.1.25"
+                "libsql": "^0.1.28"
             },
             "devDependencies": {
                 "@types/jest": "^29.2.5",
@@ -1015,9 +1015,9 @@
             }
         },
         "node_modules/@libsql/darwin-arm64": {
-            "version": "0.1.25",
-            "resolved": "https://registry.npmjs.org/@libsql/darwin-arm64/-/darwin-arm64-0.1.25.tgz",
-            "integrity": "sha512-yJBs5NGgzDB50ik4ytFHvDiF8Y8exIhXCOq7KUZhQV3obz0M/+rzOyXG3w1h0nqnAjGFTJgeFdk2HFfIEhy8lQ==",
+            "version": "0.1.28",
+            "resolved": "https://registry.npmjs.org/@libsql/darwin-arm64/-/darwin-arm64-0.1.28.tgz",
+            "integrity": "sha512-p4nldHUOhcl9ibnH1F6oiXV5Dl3PAcPB9VIjdjVvO3/URo5J7mhqRMuwJMKO5DZJJGtkKJ5IO0gu0hc90rnKIg==",
             "cpu": [
                 "arm64"
             ],
@@ -1027,9 +1027,9 @@
             ]
         },
         "node_modules/@libsql/darwin-x64": {
-            "version": "0.1.25",
-            "resolved": "https://registry.npmjs.org/@libsql/darwin-x64/-/darwin-x64-0.1.25.tgz",
-            "integrity": "sha512-pEq3DbzQcCf5zs1PSdVsdhRKk2VebwixYRdBeXIIlkqjy/kxlbW/pZs0U6QcK2MVaW+ge/Po3RvPN+Pmf31j2w==",
+            "version": "0.1.28",
+            "resolved": "https://registry.npmjs.org/@libsql/darwin-x64/-/darwin-x64-0.1.28.tgz",
+            "integrity": "sha512-WaEK+Z+wP5sr0h8EcusSGHv4Mqc3smYICeG4P/wsbRDKQ2WUMWqZrpgqaBsm+WPbXogU2vpf+qGc8BnpFZ0ggw==",
             "cpu": [
                 "x64"
             ],
@@ -1087,9 +1087,9 @@
             }
         },
         "node_modules/@libsql/linux-arm64-gnu": {
-            "version": "0.1.25",
-            "resolved": "https://registry.npmjs.org/@libsql/linux-arm64-gnu/-/linux-arm64-gnu-0.1.25.tgz",
-            "integrity": "sha512-KgceGjfJ1Fl6Gnk6o2hqQQlSy2/LwBDW0ZBv8GQ6qaapJXJI6fIMJsxAgU+MujYYjXBXCRxC4J0xAHSUw4nhZg==",
+            "version": "0.1.28",
+            "resolved": "https://registry.npmjs.org/@libsql/linux-arm64-gnu/-/linux-arm64-gnu-0.1.28.tgz",
+            "integrity": "sha512-a17ANBuOqH2L8gdyET4Kg3XggQvxWnoA+7x7sDEX5NyWNyvr7P04WzNPAT0xAOWLclC1fDD6jM5sh/fbJk/7NA==",
             "cpu": [
                 "arm64"
             ],
@@ -1099,9 +1099,9 @@
             ]
         },
         "node_modules/@libsql/linux-x64-gnu": {
-            "version": "0.1.25",
-            "resolved": "https://registry.npmjs.org/@libsql/linux-x64-gnu/-/linux-x64-gnu-0.1.25.tgz",
-            "integrity": "sha512-+M4PnnxJ0zBDaiLvK1qOBGcawd3ld2d7yQt8S13wDMX3Qm2XVeorNspTtVOIaz+DRiNONOaZdHbh+UBJiIycTg==",
+            "version": "0.1.28",
+            "resolved": "https://registry.npmjs.org/@libsql/linux-x64-gnu/-/linux-x64-gnu-0.1.28.tgz",
+            "integrity": "sha512-dkg+Ou7ApV0PHpZWd9c6NrYyc/WSNn5h/ScKotaMTLWlLL96XAMNwrYLpZpUj61I2y7QzU98XtMfiSD1Ux+VaA==",
             "cpu": [
                 "x64"
             ],
@@ -1111,9 +1111,9 @@
             ]
         },
         "node_modules/@libsql/linux-x64-musl": {
-            "version": "0.1.25",
-            "resolved": "https://registry.npmjs.org/@libsql/linux-x64-musl/-/linux-x64-musl-0.1.25.tgz",
-            "integrity": "sha512-baYCmaqMfE3TuiJcdFbSV4snC2XfoMTpUwzuh6YdkTf1MuV4bmqxke8CDujat3KprLuyRPQLAEEEDh2i1Hug4Q==",
+            "version": "0.1.28",
+            "resolved": "https://registry.npmjs.org/@libsql/linux-x64-musl/-/linux-x64-musl-0.1.28.tgz",
+            "integrity": "sha512-ZuOxCDYlG+f1IDsxstmaxLtgG9HvlLuUKs0X3um4f5F5V+P+PF8qr08gSdD1IP2pj+JBOiwhQffaEpR1wupxhQ==",
             "cpu": [
                 "x64"
             ],
@@ -1123,9 +1123,9 @@
             ]
         },
         "node_modules/@libsql/win32-x64-msvc": {
-            "version": "0.1.25",
-            "resolved": "https://registry.npmjs.org/@libsql/win32-x64-msvc/-/win32-x64-msvc-0.1.25.tgz",
-            "integrity": "sha512-keGaG4y2xBbn2GAcB9QJkzeXxUuhK3zijgfMeZS/i6BZDsym5aYkqqHXVUEsOsBmO9t24ZaDwnS71lB0nxdUiA==",
+            "version": "0.1.28",
+            "resolved": "https://registry.npmjs.org/@libsql/win32-x64-msvc/-/win32-x64-msvc-0.1.28.tgz",
+            "integrity": "sha512-2cmUiMIsJLHpetebGeeYqUYaCPWEnwMjqxwu1ZEEbA5x8r+DNmIhLrc0QSQ29p7a5u14vbZnShNOtT/XG7vKew==",
             "cpu": [
                 "x64"
             ],
@@ -3035,9 +3035,9 @@
             }
         },
         "node_modules/libsql": {
-            "version": "0.1.25",
-            "resolved": "https://registry.npmjs.org/libsql/-/libsql-0.1.25.tgz",
-            "integrity": "sha512-Wq3vmbFA64o5PCa8qIpNvMwqJB0WdINlwpEG6qOeeUbzMqyLNpB4BQaTqR9spQpLMPbmH6igjqublWp0tz9AyA==",
+            "version": "0.1.28",
+            "resolved": "https://registry.npmjs.org/libsql/-/libsql-0.1.28.tgz",
+            "integrity": "sha512-yCKlT0ntV8ZIWTPGNClhQQeH/LNAzLjbbEgBvgLb+jfQwAuTbyvPpVVLwkZzesqja1nbkWApztW0pX81Jp0pkw==",
             "cpu": [
                 "x64",
                 "arm64"
@@ -3052,12 +3052,12 @@
                 "detect-libc": "2.0.2"
             },
             "optionalDependencies": {
-                "@libsql/darwin-arm64": "0.1.25",
-                "@libsql/darwin-x64": "0.1.25",
-                "@libsql/linux-arm64-gnu": "0.1.25",
-                "@libsql/linux-x64-gnu": "0.1.25",
-                "@libsql/linux-x64-musl": "0.1.25",
-                "@libsql/win32-x64-msvc": "0.1.25"
+                "@libsql/darwin-arm64": "0.1.28",
+                "@libsql/darwin-x64": "0.1.28",
+                "@libsql/linux-arm64-gnu": "0.1.28",
+                "@libsql/linux-x64-gnu": "0.1.28",
+                "@libsql/linux-x64-musl": "0.1.28",
+                "@libsql/win32-x64-msvc": "0.1.28"
             }
         },
         "node_modules/lines-and-columns": {
@@ -4975,15 +4975,15 @@
             }
         },
         "@libsql/darwin-arm64": {
-            "version": "0.1.25",
-            "resolved": "https://registry.npmjs.org/@libsql/darwin-arm64/-/darwin-arm64-0.1.25.tgz",
-            "integrity": "sha512-yJBs5NGgzDB50ik4ytFHvDiF8Y8exIhXCOq7KUZhQV3obz0M/+rzOyXG3w1h0nqnAjGFTJgeFdk2HFfIEhy8lQ==",
+            "version": "0.1.28",
+            "resolved": "https://registry.npmjs.org/@libsql/darwin-arm64/-/darwin-arm64-0.1.28.tgz",
+            "integrity": "sha512-p4nldHUOhcl9ibnH1F6oiXV5Dl3PAcPB9VIjdjVvO3/URo5J7mhqRMuwJMKO5DZJJGtkKJ5IO0gu0hc90rnKIg==",
             "optional": true
         },
         "@libsql/darwin-x64": {
-            "version": "0.1.25",
-            "resolved": "https://registry.npmjs.org/@libsql/darwin-x64/-/darwin-x64-0.1.25.tgz",
-            "integrity": "sha512-pEq3DbzQcCf5zs1PSdVsdhRKk2VebwixYRdBeXIIlkqjy/kxlbW/pZs0U6QcK2MVaW+ge/Po3RvPN+Pmf31j2w==",
+            "version": "0.1.28",
+            "resolved": "https://registry.npmjs.org/@libsql/darwin-x64/-/darwin-x64-0.1.28.tgz",
+            "integrity": "sha512-WaEK+Z+wP5sr0h8EcusSGHv4Mqc3smYICeG4P/wsbRDKQ2WUMWqZrpgqaBsm+WPbXogU2vpf+qGc8BnpFZ0ggw==",
             "optional": true
         },
         "@libsql/hrana-client": {
@@ -5026,27 +5026,27 @@
             }
         },
         "@libsql/linux-arm64-gnu": {
-            "version": "0.1.25",
-            "resolved": "https://registry.npmjs.org/@libsql/linux-arm64-gnu/-/linux-arm64-gnu-0.1.25.tgz",
-            "integrity": "sha512-KgceGjfJ1Fl6Gnk6o2hqQQlSy2/LwBDW0ZBv8GQ6qaapJXJI6fIMJsxAgU+MujYYjXBXCRxC4J0xAHSUw4nhZg==",
+            "version": "0.1.28",
+            "resolved": "https://registry.npmjs.org/@libsql/linux-arm64-gnu/-/linux-arm64-gnu-0.1.28.tgz",
+            "integrity": "sha512-a17ANBuOqH2L8gdyET4Kg3XggQvxWnoA+7x7sDEX5NyWNyvr7P04WzNPAT0xAOWLclC1fDD6jM5sh/fbJk/7NA==",
             "optional": true
         },
         "@libsql/linux-x64-gnu": {
-            "version": "0.1.25",
-            "resolved": "https://registry.npmjs.org/@libsql/linux-x64-gnu/-/linux-x64-gnu-0.1.25.tgz",
-            "integrity": "sha512-+M4PnnxJ0zBDaiLvK1qOBGcawd3ld2d7yQt8S13wDMX3Qm2XVeorNspTtVOIaz+DRiNONOaZdHbh+UBJiIycTg==",
+            "version": "0.1.28",
+            "resolved": "https://registry.npmjs.org/@libsql/linux-x64-gnu/-/linux-x64-gnu-0.1.28.tgz",
+            "integrity": "sha512-dkg+Ou7ApV0PHpZWd9c6NrYyc/WSNn5h/ScKotaMTLWlLL96XAMNwrYLpZpUj61I2y7QzU98XtMfiSD1Ux+VaA==",
             "optional": true
         },
         "@libsql/linux-x64-musl": {
-            "version": "0.1.25",
-            "resolved": "https://registry.npmjs.org/@libsql/linux-x64-musl/-/linux-x64-musl-0.1.25.tgz",
-            "integrity": "sha512-baYCmaqMfE3TuiJcdFbSV4snC2XfoMTpUwzuh6YdkTf1MuV4bmqxke8CDujat3KprLuyRPQLAEEEDh2i1Hug4Q==",
+            "version": "0.1.28",
+            "resolved": "https://registry.npmjs.org/@libsql/linux-x64-musl/-/linux-x64-musl-0.1.28.tgz",
+            "integrity": "sha512-ZuOxCDYlG+f1IDsxstmaxLtgG9HvlLuUKs0X3um4f5F5V+P+PF8qr08gSdD1IP2pj+JBOiwhQffaEpR1wupxhQ==",
             "optional": true
         },
         "@libsql/win32-x64-msvc": {
-            "version": "0.1.25",
-            "resolved": "https://registry.npmjs.org/@libsql/win32-x64-msvc/-/win32-x64-msvc-0.1.25.tgz",
-            "integrity": "sha512-keGaG4y2xBbn2GAcB9QJkzeXxUuhK3zijgfMeZS/i6BZDsym5aYkqqHXVUEsOsBmO9t24ZaDwnS71lB0nxdUiA==",
+            "version": "0.1.28",
+            "resolved": "https://registry.npmjs.org/@libsql/win32-x64-msvc/-/win32-x64-msvc-0.1.28.tgz",
+            "integrity": "sha512-2cmUiMIsJLHpetebGeeYqUYaCPWEnwMjqxwu1ZEEbA5x8r+DNmIhLrc0QSQ29p7a5u14vbZnShNOtT/XG7vKew==",
             "optional": true
         },
         "@neon-rs/load": {
@@ -6486,16 +6486,16 @@
             "dev": true
         },
         "libsql": {
-            "version": "0.1.25",
-            "resolved": "https://registry.npmjs.org/libsql/-/libsql-0.1.25.tgz",
-            "integrity": "sha512-Wq3vmbFA64o5PCa8qIpNvMwqJB0WdINlwpEG6qOeeUbzMqyLNpB4BQaTqR9spQpLMPbmH6igjqublWp0tz9AyA==",
+            "version": "0.1.28",
+            "resolved": "https://registry.npmjs.org/libsql/-/libsql-0.1.28.tgz",
+            "integrity": "sha512-yCKlT0ntV8ZIWTPGNClhQQeH/LNAzLjbbEgBvgLb+jfQwAuTbyvPpVVLwkZzesqja1nbkWApztW0pX81Jp0pkw==",
             "requires": {
-                "@libsql/darwin-arm64": "0.1.25",
-                "@libsql/darwin-x64": "0.1.25",
-                "@libsql/linux-arm64-gnu": "0.1.25",
-                "@libsql/linux-x64-gnu": "0.1.25",
-                "@libsql/linux-x64-musl": "0.1.25",
-                "@libsql/win32-x64-msvc": "0.1.25",
+                "@libsql/darwin-arm64": "0.1.28",
+                "@libsql/darwin-x64": "0.1.28",
+                "@libsql/linux-arm64-gnu": "0.1.28",
+                "@libsql/linux-x64-gnu": "0.1.28",
+                "@libsql/linux-x64-musl": "0.1.28",
+                "@libsql/win32-x64-msvc": "0.1.28",
                 "@neon-rs/load": "^0.0.4",
                 "detect-libc": "2.0.2"
             }

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "dependencies": {
         "@libsql/hrana-client": "^0.5.5",
         "js-base64": "^3.7.5",
-        "libsql": "^0.1.25"
+        "libsql": "^0.1.28"
     },
     "devDependencies": {
         "@types/jest": "^29.2.5",

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -940,3 +940,10 @@ describe("transaction()", () => {
         c.close();
     }
 });
+
+test('raw error codes', async () => {
+    const c = createClient(config)
+    await expect(c.execute('NOT A VALID SQL')).rejects.toThrow(
+        expect.toBeLibsqlError({ code: 'SQLITE_ERROR', rawCode: 1})
+    )
+})

--- a/src/api.ts
+++ b/src/api.ts
@@ -433,13 +433,16 @@ export type InArgs = Array<InValue> | Record<string, InValue>;
 export class LibsqlError extends Error {
     /** Machine-readable error code. */
     code: string;
+    /** Raw numeric error code */
+    rawCode?: number;
     
-    constructor(message: string, code: string, cause?: Error) {
+    constructor(message: string, code: string, rawCode?: number, cause?: Error) {
         if (code !== undefined) {
             message = `${code}: ${message}`;
         }
         super(message, { cause });
         this.code = code;
+        this.rawCode = rawCode
         this.name = "LibsqlError";
     }
 }

--- a/src/hrana.ts
+++ b/src/hrana.ts
@@ -309,7 +309,7 @@ export function resultSetFromHrana(hranaRows: hrana.RowsResult): ResultSet {
 export function mapHranaError(e: unknown): unknown {
     if (e instanceof hrana.ClientError) {
         const code = mapHranaErrorCode(e);
-        return new LibsqlError(e.message, code, e);
+        return new LibsqlError(e.message, code, undefined, e);
     }
     return e;
 }

--- a/src/sqlite3.ts
+++ b/src/sqlite3.ts
@@ -340,7 +340,7 @@ function executeMultiple(db: Database.Database, sql: string): void {
 
 function mapSqliteError(e: unknown): unknown {
     if (e instanceof Database.SqliteError) {
-        return new LibsqlError(e.message, e.code, e);
+        return new LibsqlError(e.message, e.code, e.rawCode, e);
     }
     return e;
 }

--- a/src/uri.ts
+++ b/src/uri.ts
@@ -127,7 +127,7 @@ function percentDecode(text: string): string {
         return decodeURIComponent(text);
     } catch (e) {
         if (e instanceof URIError) {
-            throw new LibsqlError(`URL component has invalid percent encoding: ${e}`, "URL_INVALID", e);
+            throw new LibsqlError(`URL component has invalid percent encoding: ${e}`, "URL_INVALID", undefined, e);
         }
         throw e;
     }


### PR DESCRIPTION
Follow-up to libsql/libsql-js#47
Adds same `rawCode` property for numeric error codes to LibsqlError
class.
