### PR TITLE
chore: update usage guidance for latest Next.js version

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ const nextConfig = {
 module.exports = nextConfig
 ```
 
+> [!NOTE]
+> If you are using Next.js v13.5.5 or above, this is done automatically for you.
+
+
 ## Create a database client object
 
 ### Importing

--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ module.exports = nextConfig
 > [!NOTE]
 > If you are using Next.js v13.5.5 or above, this is done automatically for you.
 
-
 ## Create a database client object
 
 ### Importing


### PR DESCRIPTION
Added note on using @libsql/client with next.js. As of the latest version, @libsql/client is automatically handled, so there is no need to add it to `serverComponentsExternalPackages`. See https://github.com/vercel/next.js/pull/56192