### PR TITLE
Add browser support for client

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
                 "edge-light": "./lib-esm/web.js",
                 "netlify": "./lib-esm/web.js",
                 "node": "./lib-esm/node.js",
+                "browser": "./lib-esm/web.js",
                 "default": "./lib-esm/node.js"
             },
             "require": "./lib-cjs/node.js"


### PR DESCRIPTION
This PR fixes #107 where `@libsql/client` is imported on a browser environment (for example, while importing types) and acts as a safety net for future library integrations so we can defend better against integrations.

With this change, imports from a browser environment are resolved to our web package.