### PR TITLE
Convert booleans to integers instead of BigInt

### DIFF
--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -304,8 +304,14 @@ describe("values", () => {
     testRoundtrip("Uint8Array", array, buf);
 
     testRoundtrip("null", null, null);
-    testRoundtrip("true", true, 1, "bigint");
-    testRoundtrip("false", false, 0, "bigint");
+    testRoundtrip("true", true, 1n, "bigint");
+    testRoundtrip("false", false, 0n, "bigint");
+    testRoundtrip("true", true, 1, "number");
+    testRoundtrip("false", false, 0, "number");
+    testRoundtrip("true", true, "1", "string");
+    testRoundtrip("false", false, "0", "string");
+    testRoundtrip("true", true, 1);
+    testRoundtrip("false", false, 0);
     
     testRoundtrip("Date", new Date("2023-01-02T12:34:56Z"), 1672662896000, "bigint");
 

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -304,8 +304,8 @@ describe("values", () => {
     testRoundtrip("Uint8Array", array, buf);
 
     testRoundtrip("null", null, null);
-    testRoundtrip("true", true, 1n, "bigint");
-    testRoundtrip("false", false, 0n, "bigint");
+    testRoundtrip("true", true, 1, "bigint");
+    testRoundtrip("false", false, 0, "bigint");
     
     testRoundtrip("Date", new Date("2023-01-02T12:34:56Z"), 1672662896000, "bigint");
 

--- a/src/sqlite3.ts
+++ b/src/sqlite3.ts
@@ -315,7 +315,7 @@ function valueToSql(value: InValue): unknown {
         }
         return value;
     } else if (typeof value === "boolean") {
-        return value ? 1n : 0n;
+        return value ? 1 : 0;
     } else if (value instanceof ArrayBuffer) {
         return Buffer.from(value);
     } else if (value instanceof Date) {


### PR DESCRIPTION
This PR fixes an issue where using booleans breaks some apps. At least it is breaking using Bun with Prisma as [shown in this comment](https://github.com/libsql/libsql-client-ts/pull/113#issuecomment-1822542472) due to the usage of BigInt as values.

This PR changes the boolean value from BigInt to normal integers.